### PR TITLE
style: Update code format with newer `clang-format` tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   check:
     name: Check code format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 
 .test:static:
   stage: test
-  image: ubuntu:20.04
+  image: ubuntu:24.04
   needs: []
   before_script:
     - apt-get update && apt-get install -y git clang-format pcregrep

--- a/add-ons/src/mender-configure.c
+++ b/add-ons/src/mender-configure.c
@@ -61,7 +61,7 @@ static mender_configure_callbacks_t mender_configure_callbacks;
  * @brief Mender configure keystore
  */
 static mender_keystore_t *mender_configure_keystore = NULL;
-static void *             mender_configure_mutex    = NULL;
+static void              *mender_configure_mutex    = NULL;
 
 /**
  * @brief Mender configure artifact name
@@ -99,9 +99,9 @@ mender_err_t
 mender_configure_init(void *config, void *callbacks) {
 
     assert(NULL != config);
-    char *       device_config      = NULL;
-    cJSON *      json_device_config = NULL;
-    char *       artifact_name;
+    char        *device_config      = NULL;
+    cJSON       *json_device_config = NULL;
+    char        *artifact_name;
     mender_err_t ret;
 
     /* Save configuration */
@@ -243,9 +243,9 @@ END:
 mender_err_t
 mender_configure_set(mender_keystore_t *configuration) {
 
-    cJSON *      json_device_config = NULL;
-    cJSON *      json_config        = NULL;
-    char *       device_config      = NULL;
+    cJSON       *json_device_config = NULL;
+    cJSON       *json_config        = NULL;
+    char        *device_config      = NULL;
     mender_err_t ret;
 
     /* Take mutex used to protect access to the configuration key-store */
@@ -443,8 +443,8 @@ mender_configure_download_artifact_callback(
     (void)data;
     (void)index;
     (void)length;
-    cJSON *      json_device_config = NULL;
-    char *       device_config      = NULL;
+    cJSON       *json_device_config = NULL;
+    char        *device_config      = NULL;
     mender_err_t ret                = MENDER_OK;
 
     /* Check meta-data */

--- a/add-ons/src/mender-inventory.c
+++ b/add-ons/src/mender-inventory.c
@@ -55,7 +55,7 @@ static mender_inventory_config_t mender_inventory_config;
  * @brief Mender inventory keystore
  */
 static mender_keystore_t *mender_inventory_keystore = NULL;
-static void *             mender_inventory_mutex    = NULL;
+static void              *mender_inventory_mutex    = NULL;
 
 /**
  * @brief Mender inventory work handle

--- a/add-ons/src/mender-troubleshoot.c
+++ b/add-ons/src/mender-troubleshoot.c
@@ -96,10 +96,10 @@ typedef enum {
  * Proto message header properties
  */
 typedef struct {
-    uint16_t *                               terminal_width;  /**< Terminal width */
-    uint16_t *                               terminal_height; /**< Terminal heigth */
-    char *                                   user_id;         /**< User ID */
-    uint32_t *                               timeout;         /**< Timeout */
+    uint16_t                                *terminal_width;  /**< Terminal width */
+    uint16_t                                *terminal_height; /**< Terminal heigth */
+    char                                    *user_id;         /**< User ID */
+    uint32_t                                *timeout;         /**< Timeout */
     mender_troubleshoot_properties_status_t *status;          /**< Status */
 } mender_troubleshoot_protohdr_properties_t;
 
@@ -108,8 +108,8 @@ typedef struct {
  */
 typedef struct {
     mender_troubleshoot_protohdr_type_t        proto;      /**< Proto type */
-    char *                                     typ;        /**< Message type */
-    char *                                     sid;        /**< Session ID */
+    char                                      *typ;        /**< Message type */
+    char                                      *sid;        /**< Session ID */
     mender_troubleshoot_protohdr_properties_t *properties; /**< Properties */
 } mender_troubleshoot_protohdr_t;
 
@@ -118,7 +118,7 @@ typedef struct {
  */
 typedef struct {
     mender_troubleshoot_protohdr_t *protohdr; /**< Header */
-    char *                          body;     /**< Body */
+    char                           *body;     /**< Body */
 } mender_troubleshoot_protomsg_t;
 
 /**
@@ -184,10 +184,10 @@ static mender_err_t mender_troubleshoot_mender_client_message_handler(mender_tro
  * @param response Response to be sent back to the server, NULL if no response to send
  * @return MENDER_OK if the function succeeds, error code if an error occured
  */
-static mender_err_t mender_troubleshoot_format_acknowledgment(mender_troubleshoot_protomsg_t *        protomsg,
-                                                              char *                                  sid,
+static mender_err_t mender_troubleshoot_format_acknowledgment(mender_troubleshoot_protomsg_t         *protomsg,
+                                                              char                                   *sid,
                                                               mender_troubleshoot_properties_status_t status,
-                                                              mender_troubleshoot_protomsg_t **       response);
+                                                              mender_troubleshoot_protomsg_t        **response);
 
 /**
  * @brief Function called to send shell ping protomsg
@@ -403,7 +403,7 @@ mender_troubleshoot_shell_print(uint8_t *data, size_t length) {
     assert(NULL != data);
     mender_troubleshoot_protomsg_t *protomsg = NULL;
     mender_err_t                    ret      = MENDER_OK;
-    void *                          payload  = NULL;
+    void                           *payload  = NULL;
 
     /* Check if a session is already opened */
     if (NULL == mender_troubleshoot_shell_sid) {
@@ -573,7 +573,7 @@ mender_troubleshoot_data_received_callback(void *data, size_t length) {
     mender_err_t                    ret = MENDER_OK;
     mender_troubleshoot_protomsg_t *protomsg;
     mender_troubleshoot_protomsg_t *response = NULL;
-    void *                          payload  = NULL;
+    void                           *payload  = NULL;
 
     /* Unpack and decode message */
     if (NULL == (protomsg = mender_troubleshoot_unpack_protomsg(data, length))) {
@@ -854,10 +854,10 @@ FAIL:
 }
 
 static mender_err_t
-mender_troubleshoot_format_acknowledgment(mender_troubleshoot_protomsg_t *        protomsg,
-                                          char *                                  sid,
+mender_troubleshoot_format_acknowledgment(mender_troubleshoot_protomsg_t         *protomsg,
+                                          char                                   *sid,
                                           mender_troubleshoot_properties_status_t status,
-                                          mender_troubleshoot_protomsg_t **       response) {
+                                          mender_troubleshoot_protomsg_t        **response) {
 
     assert(NULL != protomsg);
     assert(NULL != protomsg->protohdr);
@@ -919,7 +919,7 @@ mender_troubleshoot_send_shell_ping_protomsg(void) {
 
     mender_troubleshoot_protomsg_t *protomsg = NULL;
     mender_err_t                    ret      = MENDER_OK;
-    void *                          payload  = NULL;
+    void                           *payload  = NULL;
     size_t                          length   = 0;
 
     /* Send shell ping message */
@@ -993,7 +993,7 @@ mender_troubleshoot_send_shell_stop_protomsg(void) {
 
     mender_troubleshoot_protomsg_t *protomsg = NULL;
     mender_err_t                    ret      = MENDER_OK;
-    void *                          payload  = NULL;
+    void                           *payload  = NULL;
     size_t                          length   = 0;
 
     /* Send shell stop message */

--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -130,13 +130,13 @@ mender_err_t
 mender_api_perform_authentication(void) {
 
     mender_err_t ret;
-    char *       public_key_pem   = NULL;
-    cJSON *      json_identity    = NULL;
-    char *       identity         = NULL;
-    cJSON *      json_payload     = NULL;
-    char *       payload          = NULL;
-    char *       response         = NULL;
-    char *       signature        = NULL;
+    char        *public_key_pem   = NULL;
+    cJSON       *json_identity    = NULL;
+    char        *identity         = NULL;
+    cJSON       *json_payload     = NULL;
+    char        *payload          = NULL;
+    char        *response         = NULL;
+    char        *signature        = NULL;
     size_t       signature_length = 0;
     int          status           = 0;
 
@@ -250,8 +250,8 @@ mender_api_check_for_deployment(char **id, char **artifact_name, char **uri) {
     assert(NULL != artifact_name);
     assert(NULL != uri);
     mender_err_t ret;
-    char *       path     = NULL;
-    char *       response = NULL;
+    char        *path     = NULL;
+    char        *response = NULL;
     int          status   = 0;
 
     /* Compute path */
@@ -348,11 +348,11 @@ mender_api_publish_deployment_status(char *id, mender_deployment_status_t deploy
 
     assert(NULL != id);
     mender_err_t ret;
-    char *       value        = NULL;
-    cJSON *      json_payload = NULL;
-    char *       payload      = NULL;
-    char *       path         = NULL;
-    char *       response     = NULL;
+    char        *value        = NULL;
+    cJSON       *json_payload = NULL;
+    char        *payload      = NULL;
+    char        *path         = NULL;
+    char        *response     = NULL;
     int          status       = 0;
 
     /* Deployment status to string */
@@ -455,7 +455,7 @@ mender_api_download_configuration_data(mender_keystore_t **configuration) {
 
     assert(NULL != configuration);
     mender_err_t ret;
-    char *       response = NULL;
+    char        *response = NULL;
     int          status   = 0;
 
     /* Perform HTTP request */
@@ -506,9 +506,9 @@ mender_err_t
 mender_api_publish_configuration_data(mender_keystore_t *configuration) {
 
     mender_err_t ret;
-    cJSON *      json_configuration = NULL;
-    char *       payload            = NULL;
-    char *       response           = NULL;
+    cJSON       *json_configuration = NULL;
+    char        *payload            = NULL;
+    char        *response           = NULL;
     int          status             = 0;
 
     /* Format payload */
@@ -621,8 +621,8 @@ mender_err_t
 mender_api_publish_inventory_data(mender_keystore_t *inventory) {
 
     mender_err_t ret;
-    char *       payload  = NULL;
-    char *       response = NULL;
+    char        *payload  = NULL;
+    char        *response = NULL;
     int          status   = 0;
 
     /* Format payload */
@@ -733,9 +733,9 @@ static mender_err_t
 mender_api_http_text_callback(mender_http_client_event_t event, void *data, size_t data_length, void *params) {
 
     assert(NULL != params);
-    char **      response = (char **)params;
+    char       **response = (char **)params;
     mender_err_t ret      = MENDER_OK;
-    char *       tmp;
+    char        *tmp;
 
     /* Treatment depending of the event */
     switch (event) {

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -136,14 +136,14 @@ mender_artifact_create_ctx(void) {
 
 mender_err_t
 mender_artifact_process_data(mender_artifact_ctx_t *ctx,
-                             void *                 input_data,
+                             void                  *input_data,
                              size_t                 input_length,
                              mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t)) {
 
     assert(NULL != ctx);
     assert(NULL != callback);
     mender_err_t ret = MENDER_OK;
-    void *       tmp;
+    void        *tmp;
 
     /* Copy data to the end of the internal buffer */
     if ((NULL != input_data) && (0 != input_length)) {
@@ -342,7 +342,7 @@ static mender_err_t
 mender_artifact_check_version(mender_artifact_ctx_t *ctx) {
 
     assert(NULL != ctx);
-    cJSON *      object = NULL;
+    cJSON       *object = NULL;
     mender_err_t ret    = MENDER_DONE;
 
     /* Check if all data have been received */
@@ -402,7 +402,7 @@ static mender_err_t
 mender_artifact_read_header_info(mender_artifact_ctx_t *ctx) {
 
     assert(NULL != ctx);
-    cJSON *      object = NULL;
+    cJSON       *object = NULL;
     mender_err_t ret    = MENDER_DONE;
 
     /* Check if all data have been received */

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -89,7 +89,7 @@ static mender_client_state_t mender_client_state = MENDER_CLIENT_STATE_INITIALIZ
  * @brief Counter and mutex for the management of network connect/release callbacks
  */
 static uint8_t mender_client_network_count = 0;
-static void *  mender_client_network_mutex = NULL;
+static void   *mender_client_network_mutex = NULL;
 
 /**
  * @brief Deployment data (ID, artifact name and payload types), used to report deployment status after rebooting
@@ -112,14 +112,14 @@ typedef struct {
  */
 static mender_client_artifact_type_t **mender_client_artifact_types_list  = NULL;
 static size_t                          mender_client_artifact_types_count = 0;
-static void *                          mender_client_artifact_types_mutex = NULL;
+static void                           *mender_client_artifact_types_mutex = NULL;
 
 /**
  * @brief Mender client add-ons list and mutex
  */
 static mender_addon_instance_t **mender_client_addons_list  = NULL;
 static size_t                    mender_client_addons_count = 0;
-static void *                    mender_client_addons_mutex = NULL;
+static void                     *mender_client_addons_mutex = NULL;
 
 /**
  * @brief Mender client work handle
@@ -344,7 +344,7 @@ mender_client_register_artifact_type(char *type,
                                      char *artifact_name) {
 
     assert(NULL != type);
-    mender_client_artifact_type_t * artifact_type;
+    mender_client_artifact_type_t  *artifact_type;
     mender_client_artifact_type_t **tmp;
     mender_err_t                    ret;
 
@@ -695,7 +695,7 @@ END:
 static mender_err_t
 mender_client_initialization_work_function(void) {
 
-    char *       deployment_data = NULL;
+    char        *deployment_data = NULL;
     mender_err_t ret;
 
     /* Retrieve or generate authentication keys */
@@ -1013,7 +1013,7 @@ static mender_err_t
 mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length) {
 
     assert(NULL != type);
-    cJSON *      json_types;
+    cJSON       *json_types;
     mender_err_t ret;
 
     /* Take mutex used to protect access to the artifact types management list */

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -33,7 +33,7 @@ mender_utils_http_status_to_string(int status) {
     /* Definition of status strings */
     const struct {
         uint16_t status;
-        char *   str;
+        char    *str;
     } desc[] = { { 100, "Continue" },
                  { 101, "Switching Protocols" },
                  { 103, "Early Hints" },

--- a/include/mender-api.h
+++ b/include/mender-api.h
@@ -39,10 +39,10 @@ extern "C" {
  */
 typedef struct {
     mender_keystore_t *identity;      /**< Identity of the device */
-    char *             artifact_name; /**< Artifact name */
-    char *             device_type;   /**< Device type */
-    char *             host;          /**< URL of the mender server */
-    char *             tenant_token;  /**< Tenant token used to authenticate on the mender server (optional) */
+    char              *artifact_name; /**< Artifact name */
+    char              *device_type;   /**< Device type */
+    char              *host;          /**< URL of the mender server */
+    char              *tenant_token;  /**< Tenant token used to authenticate on the mender server (optional) */
 } mender_api_config_t;
 
 /**

--- a/include/mender-artifact.h
+++ b/include/mender-artifact.h
@@ -46,7 +46,7 @@ typedef enum {
  * @brief Artifact payloads
  */
 typedef struct {
-    char * type;      /**< Type of the payload */
+    char  *type;      /**< Type of the payload */
     cJSON *meta_data; /**< Meta-data from the header tarball, NULL if no meta-data */
 } mender_artifact_payload_t;
 
@@ -56,7 +56,7 @@ typedef struct {
 typedef struct {
     mender_artifact_stream_state_t stream_state; /**< Stream state of the artifact processing */
     struct {
-        void * data;   /**< Data received, concatenated chunk by chunk */
+        void  *data;   /**< Data received, concatenated chunk by chunk */
         size_t length; /**< Length of the data received */
     } input;           /**< Input data of the artifact */
     struct {
@@ -64,7 +64,7 @@ typedef struct {
         mender_artifact_payload_t *values; /**< Values of payloads in the artifact */
     } payloads;                            /**< Payloads of the artifact */
     struct {
-        char * name;  /**< Name of the file currently parsed */
+        char  *name;  /**< Name of the file currently parsed */
         size_t size;  /**< Size of the file currently parsed (bytes) */
         size_t index; /**< Index of the data in the file currently parsed (bytes), incremented block by block */
     } file;           /**< Information about the file currently parsed */
@@ -85,7 +85,7 @@ mender_artifact_ctx_t *mender_artifact_create_ctx(void);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_artifact_process_data(mender_artifact_ctx_t *ctx,
-                                          void *                 input_data,
+                                          void                  *input_data,
                                           size_t                 input_length,
                                           mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t));
 

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -40,10 +40,10 @@ extern "C" {
  */
 typedef struct {
     mender_keystore_t *identity;                     /**< Identity of the device */
-    char *             artifact_name;                /**< Artifact name */
-    char *             device_type;                  /**< Device type */
-    char *             host;                         /**< URL of the mender server */
-    char *             tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
+    char              *artifact_name;                /**< Artifact name */
+    char              *device_type;                  /**< Device type */
+    char              *host;                         /**< URL of the mender server */
+    char              *tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
     int32_t            authentication_poll_interval; /**< Authentication poll interval, default is 60 seconds, -1 permits to disable periodic execution */
     int32_t            update_poll_interval;         /**< Update poll interval, default is 1800 seconds, -1 permits to disable periodic execution */
     bool               recommissioning;              /**< Used to force creation of new authentication keys */

--- a/include/mender-http.h
+++ b/include/mender-http.h
@@ -80,14 +80,14 @@ mender_err_t mender_http_init(mender_http_config_t *config);
  * @param status Status code
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_http_perform(char *               jwt,
-                                 char *               path,
+mender_err_t mender_http_perform(char                *jwt,
+                                 char                *path,
                                  mender_http_method_t method,
-                                 char *               payload,
-                                 char *               signature,
+                                 char                *payload,
+                                 char                *signature,
                                  mender_err_t (*callback)(mender_http_client_event_t, void *, size_t, void *),
                                  void *params,
-                                 int * status);
+                                 int  *status);
 
 /**
  * @brief Release mender http

--- a/include/mender-scheduler.h
+++ b/include/mender-scheduler.h
@@ -40,7 +40,7 @@ extern "C" {
 typedef struct {
     mender_err_t (*function)(void); /**< Work function */
     int32_t period;                 /**< Work period (seconds), negative or null value permits to disable periodic execution */
-    char *  name;                   /**< Work name */
+    char   *name;                   /**< Work name */
 } mender_scheduler_work_params_t;
 
 /**

--- a/include/mender-storage.h
+++ b/include/mender-storage.h
@@ -59,9 +59,9 @@ mender_err_t mender_storage_set_authentication_keys(unsigned char *private_key, 
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_storage_get_authentication_keys(unsigned char **private_key,
-                                                    size_t *        private_key_length,
+                                                    size_t         *private_key_length,
                                                     unsigned char **public_key,
-                                                    size_t *        public_key_length);
+                                                    size_t         *public_key_length);
 
 /**
  * @brief Delete authentication keys

--- a/platform/flash/posix/src/mender-flash.c
+++ b/platform/flash/posix/src/mender-flash.c
@@ -111,7 +111,7 @@ mender_flash_close(void *handle) {
 mender_err_t
 mender_flash_set_pending_image(void *handle) {
 
-    FILE *       file;
+    FILE        *file;
     mender_err_t ret = MENDER_OK;
 
     /* Check flash handle */

--- a/platform/net/esp-idf/src/mender-http.c
+++ b/platform/net/esp-idf/src/mender-http.c
@@ -67,14 +67,14 @@ mender_http_init(mender_http_config_t *config) {
 }
 
 mender_err_t
-mender_http_perform(char *               jwt,
-                    char *               path,
+mender_http_perform(char                *jwt,
+                    char                *path,
                     mender_http_method_t method,
-                    char *               payload,
-                    char *               signature,
+                    char                *payload,
+                    char                *signature,
                     mender_err_t (*callback)(mender_http_client_event_t, void *, size_t, void *),
                     void *params,
-                    int * status) {
+                    int  *status) {
 
     assert(NULL != path);
     assert(NULL != callback);
@@ -82,8 +82,8 @@ mender_http_perform(char *               jwt,
     esp_err_t                err;
     mender_err_t             ret    = MENDER_OK;
     esp_http_client_handle_t client = NULL;
-    char *                   url    = NULL;
-    char *                   bearer = NULL;
+    char                    *url    = NULL;
+    char                    *bearer = NULL;
 
     /* Compute URL if required */
     if ((false == mender_utils_strbeginwith(path, "http://")) && (false == mender_utils_strbeginwith(path, "https://"))) {

--- a/platform/net/esp-idf/src/mender-websocket.c
+++ b/platform/net/esp-idf/src/mender-websocket.c
@@ -112,8 +112,8 @@ mender_websocket_connect(
     assert(NULL != handle);
     esp_err_t    err;
     mender_err_t ret    = MENDER_OK;
-    char *       url    = NULL;
-    char *       bearer = NULL;
+    char        *url    = NULL;
+    char        *bearer = NULL;
 
     /* Allocate a new handle */
     if (NULL == (*handle = malloc(sizeof(mender_websocket_handle_t)))) {
@@ -268,7 +268,7 @@ mender_websocket_event_handler(void *handler_args, esp_event_base_t base, int32_
     assert(NULL != handler_args);
     (void)base;
     assert(NULL != event_data);
-    mender_websocket_handle_t * handle = (mender_websocket_handle_t *)handler_args;
+    mender_websocket_handle_t  *handle = (mender_websocket_handle_t *)handler_args;
     esp_websocket_event_data_t *data   = (esp_websocket_event_data_t *)event_data;
 
     /* Treatment depending of the event */

--- a/platform/net/generic/curl/src/mender-http.c
+++ b/platform/net/generic/curl/src/mender-http.c
@@ -89,24 +89,24 @@ mender_http_init(mender_http_config_t *config) {
 }
 
 mender_err_t
-mender_http_perform(char *               jwt,
-                    char *               path,
+mender_http_perform(char                *jwt,
+                    char                *path,
                     mender_http_method_t method,
-                    char *               payload,
-                    char *               signature,
+                    char                *payload,
+                    char                *signature,
                     mender_err_t (*callback)(mender_http_client_event_t, void *, size_t, void *),
                     void *params,
-                    int * status) {
+                    int  *status) {
 
     assert(NULL != path);
     assert(NULL != callback);
     assert(NULL != status);
     CURLcode           err;
     mender_err_t       ret             = MENDER_OK;
-    CURL *             curl            = NULL;
-    char *             url             = NULL;
-    char *             bearer          = NULL;
-    char *             x_men_signature = NULL;
+    CURL              *curl            = NULL;
+    char              *url             = NULL;
+    char              *bearer          = NULL;
+    char              *x_men_signature = NULL;
     struct curl_slist *headers         = NULL;
 
     /* Compute URL if required */

--- a/platform/net/generic/curl/src/mender-websocket.c
+++ b/platform/net/generic/curl/src/mender-websocket.c
@@ -58,7 +58,7 @@
  * @brief Websocket handle
  */
 typedef struct {
-    CURL *             client;        /**< Websocket client handle */
+    CURL              *client;        /**< Websocket client handle */
     struct curl_slist *headers;       /**< Websocket client headers */
     pthread_t          thread_handle; /**< Websocket thread handle */
     bool               abort;         /**< Flag used to indicate connection should be terminated */
@@ -127,8 +127,8 @@ mender_websocket_connect(
     CURLcode     err_curl;
     int          err_pthread;
     mender_err_t ret    = MENDER_OK;
-    char *       url    = NULL;
-    char *       bearer = NULL;
+    char        *url    = NULL;
+    char        *bearer = NULL;
 
     /* Allocate a new handle */
     if (NULL == (*handle = malloc(sizeof(mender_websocket_handle_t)))) {

--- a/platform/net/generic/weak/src/mender-http.c
+++ b/platform/net/generic/weak/src/mender-http.c
@@ -37,14 +37,14 @@ mender_http_init(mender_http_config_t *config) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_http_perform(char *               jwt,
-                    char *               path,
+mender_http_perform(char                *jwt,
+                    char                *path,
                     mender_http_method_t method,
-                    char *               payload,
-                    char *               signature,
+                    char                *payload,
+                    char                *signature,
                     mender_err_t (*callback)(mender_http_client_event_t, void *, size_t, void *),
                     void *params,
-                    int * status) {
+                    int  *status) {
 
     (void)jwt;
     (void)path;

--- a/platform/net/zephyr/src/mender-http.c
+++ b/platform/net/zephyr/src/mender-http.c
@@ -51,7 +51,7 @@
  */
 typedef struct {
     mender_err_t (*callback)(mender_http_client_event_t, void *, size_t, void *); /**< Callback to be invoked when data are received */
-    void *       params;                                                          /**< Callback parameters */
+    void        *params;                                                          /**< Callback parameters */
     mender_err_t ret;                                                             /**< Last callback return value */
 } mender_http_request_context;
 
@@ -88,14 +88,14 @@ mender_http_init(mender_http_config_t *config) {
 }
 
 mender_err_t
-mender_http_perform(char *               jwt,
-                    char *               path,
+mender_http_perform(char                *jwt,
+                    char                *path,
                     mender_http_method_t method,
-                    char *               payload,
-                    char *               signature,
+                    char                *payload,
+                    char                *signature,
                     mender_err_t (*callback)(mender_http_client_event_t, void *, size_t, void *),
                     void *params,
-                    int * status) {
+                    int  *status) {
 
     assert(NULL != path);
     assert(NULL != callback);
@@ -103,11 +103,11 @@ mender_http_perform(char *               jwt,
     mender_err_t                ret;
     struct http_request         request;
     mender_http_request_context request_context;
-    char *                      header_fields[5] = { NULL, NULL, NULL, NULL, NULL };
+    char                       *header_fields[5] = { NULL, NULL, NULL, NULL, NULL };
     size_t                      header_index     = 0;
-    char *                      host             = NULL;
-    char *                      port             = NULL;
-    char *                      url              = NULL;
+    char                       *host             = NULL;
+    char                       *port             = NULL;
+    char                       *url              = NULL;
     int                         sock             = -1;
 
     /* Initialize request */

--- a/platform/net/zephyr/src/mender-websocket.c
+++ b/platform/net/zephyr/src/mender-websocket.c
@@ -131,11 +131,11 @@ mender_websocket_connect(
     assert(NULL != handle);
     mender_err_t             ret;
     struct websocket_request request;
-    char *                   header_fields[3] = { NULL, NULL, NULL };
+    char                    *header_fields[3] = { NULL, NULL, NULL };
     size_t                   header_index     = 0;
-    char *                   host             = NULL;
-    char *                   port             = NULL;
-    char *                   url              = NULL;
+    char                    *host             = NULL;
+    char                    *port             = NULL;
+    char                    *url              = NULL;
 
     /* Initialize request */
     memset(&request, 0, sizeof(struct websocket_request));

--- a/platform/shell/zephyr/src/mender-shell.c
+++ b/platform/shell/zephyr/src/mender-shell.c
@@ -106,7 +106,7 @@ K_THREAD_STACK_DEFINE(mender_shell_tx_work_queue_stack, CONFIG_MENDER_SHELL_TX_W
  */
 typedef struct {
     shell_transport_handler_t evt_handler;                                        /**< Handler function registered by shell init */
-    void *                    context;                                            /**< Context registered by shell init */
+    void                     *context;                                            /**< Context registered by shell init */
     struct ring_buf           rx_ringbuf;                                         /**< Rx ring buffer handler */
     uint8_t                   rx_buffer[CONFIG_MENDER_SHELL_RX_RING_BUFFER_SIZE]; /**< Rx ring buffer */
     struct ring_buf           tx_ringbuf;                                         /**< Tx ring buffer handler */
@@ -207,7 +207,7 @@ mender_shell_transport_api_write(const struct shell_transport *transport, const 
     assert(NULL != data);
     assert(NULL != cnt);
     mender_shell_context_t *ctx = (mender_shell_context_t *)transport->ctx;
-    uint8_t *               buffer;
+    uint8_t                *buffer;
 
     /* Cancel pending tx work */
     k_work_cancel_delayable(&ctx->tx_work_handle);

--- a/platform/storage/posix/src/mender-storage.c
+++ b/platform/storage/posix/src/mender-storage.c
@@ -175,7 +175,7 @@ mender_storage_set_deployment_data(char *deployment_data) {
 
     assert(NULL != deployment_data);
     size_t deployment_data_length = strlen(deployment_data);
-    FILE * f;
+    FILE  *f;
 
     /* Write deployment data */
     if (NULL == (f = fopen(MENDER_STORAGE_NVS_DEPLOYMENT_DATA, "wb"))) {
@@ -198,7 +198,7 @@ mender_storage_get_deployment_data(char **deployment_data) {
     assert(NULL != deployment_data);
     size_t deployment_data_length = 0;
     long   length;
-    FILE * f;
+    FILE  *f;
 
     /* Read deployment data */
     if (NULL == (f = fopen(MENDER_STORAGE_NVS_DEPLOYMENT_DATA, "rb"))) {
@@ -249,7 +249,7 @@ mender_storage_set_device_config(char *device_config) {
 
     assert(NULL != device_config);
     size_t device_config_length = strlen(device_config);
-    FILE * f;
+    FILE  *f;
 
     /* Write device configuration */
     if (NULL == (f = fopen(MENDER_STORAGE_NVS_DEVICE_CONFIG, "wb"))) {
@@ -272,7 +272,7 @@ mender_storage_get_device_config(char **device_config) {
     assert(NULL != device_config);
     size_t device_config_length = 0;
     long   length;
-    FILE * f;
+    FILE  *f;
 
     /* Read device configuration */
     if (NULL == (f = fopen(MENDER_STORAGE_NVS_DEVICE_CONFIG, "rb"))) {

--- a/platform/tls/generic/cryptoauthlib/src/mender-tls.c
+++ b/platform/tls/generic/cryptoauthlib/src/mender-tls.c
@@ -185,7 +185,7 @@ mender_tls_sign_payload(char *payload, char **signature, size_t *signature_lengt
     uint8_t *s = &sign[32];
     uint8_t  asn1[72];
     size_t   index = 0;
-    char *   tmp;
+    char    *tmp;
 
     /* Compute digest (sha256) of the payload */
     if (ATCA_SUCCESS != atcab_hw_sha2_256(payload, strlen(payload), digest)) {

--- a/platform/tls/generic/mbedtls/src/mender-tls.c
+++ b/platform/tls/generic/mbedtls/src/mender-tls.c
@@ -67,9 +67,9 @@ static size_t         mender_tls_public_key_length  = 0;
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 static mender_err_t mender_tls_generate_authentication_keys(unsigned char **private_key,
-                                                            size_t *        private_key_length,
+                                                            size_t         *private_key_length,
                                                             unsigned char **public_key,
-                                                            size_t *        public_key_length);
+                                                            size_t         *public_key_length);
 
 /**
  * @brief Write a buffer of PEM information from a DER encoded buffer
@@ -177,12 +177,12 @@ mender_tls_sign_payload(char *payload, char **signature, size_t *signature_lengt
     assert(NULL != signature);
     assert(NULL != signature_length);
     int                       ret;
-    mbedtls_pk_context *      pk_context = NULL;
+    mbedtls_pk_context       *pk_context = NULL;
     mbedtls_ctr_drbg_context *ctr_drbg   = NULL;
-    mbedtls_entropy_context * entropy    = NULL;
-    unsigned char *           sig        = NULL;
+    mbedtls_entropy_context  *entropy    = NULL;
+    unsigned char            *sig        = NULL;
     size_t                    sig_length;
-    char *                    tmp;
+    char                     *tmp;
 #ifdef MBEDTLS_ERROR_C
     char err[128];
 #endif /* MBEDTLS_ERROR_C */
@@ -344,10 +344,10 @@ mender_tls_generate_authentication_keys(unsigned char **private_key, size_t *pri
     assert(NULL != public_key);
     assert(NULL != public_key_length);
     int                       ret;
-    mbedtls_pk_context *      pk_context = NULL;
+    mbedtls_pk_context       *pk_context = NULL;
     mbedtls_ctr_drbg_context *ctr_drbg   = NULL;
-    mbedtls_entropy_context * entropy    = NULL;
-    unsigned char *           tmp;
+    mbedtls_entropy_context  *entropy    = NULL;
+    unsigned char            *tmp;
 
 #ifdef MBEDTLS_ERROR_C
     char err[128];

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -235,8 +235,8 @@ str_replace(char *input, char *search, char *replace) {
 
     regex_t    regex;
     regmatch_t match;
-    char *     str                   = input;
-    char *     output                = NULL;
+    char      *str                   = input;
+    char      *output                = NULL;
     size_t     index                 = 0;
     int        previous_match_finish = 0;
 
@@ -328,7 +328,7 @@ static mender_err_t
 shell_write_cb(uint8_t *data, size_t length) {
 
     mender_err_t ret = MENDER_OK;
-    char *       buffer, *tmp;
+    char        *buffer, *tmp;
 
     /* Ensure new line is "\r\n" to have a proper display of the data in the shell */
     if (NULL == (buffer = strndup((char *)data, length))) {
@@ -491,13 +491,13 @@ main(int argc, char **argv) {
     /* Initialize mender-client */
     mender_keystore_t         identity[]              = { { .name = "mac", .value = mac_address }, { .name = NULL, .value = NULL } };
     mender_client_config_t    mender_client_config    = { .identity                     = identity,
-                                                    .artifact_name                = artifact_name,
-                                                    .device_type                  = device_type,
-                                                    .host                         = NULL,
-                                                    .tenant_token                 = tenant_token,
-                                                    .authentication_poll_interval = 0,
-                                                    .update_poll_interval         = 0,
-                                                    .recommissioning              = false };
+                                                          .artifact_name                = artifact_name,
+                                                          .device_type                  = device_type,
+                                                          .host                         = NULL,
+                                                          .tenant_token                 = tenant_token,
+                                                          .authentication_poll_interval = 0,
+                                                          .update_poll_interval         = 0,
+                                                          .recommissioning              = false };
     mender_client_callbacks_t mender_client_callbacks = { .network_connect        = network_connect_cb,
                                                           .network_release        = network_release_cb,
                                                           .authentication_success = authentication_success_cb,


### PR DESCRIPTION
Ubuntu 20.04 used in CI was getting a bit dated.

Updated CI job with latest Ubuntu LTS release (with newer `clang-format`) and format all the code accordingly.