### PR TITLE
feat: accept user provided keys

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -686,11 +686,13 @@ END:
 static mender_err_t
 mender_client_initialization_work_function(void) {
 
+    assert(NULL != mender_client_callbacks.get_user_provided_keys);
+
     char        *storage_deployment_data = NULL;
     mender_err_t ret;
 
     /* Retrieve or generate authentication keys */
-    if (MENDER_OK != (ret = mender_tls_init_authentication_keys(mender_client_config.recommissioning))) {
+    if (MENDER_OK != (ret = mender_tls_init_authentication_keys(mender_client_callbacks.get_user_provided_keys, mender_client_config.recommissioning))) {
         mender_log_error("Unable to retrieve or generate authentication keys");
         goto END;
     }

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -59,6 +59,8 @@ typedef struct {
     mender_err_t (*deployment_status)(mender_deployment_status_t, char *); /**< Invoked on transition changes to inform of the new deployment status */
     mender_err_t (*restart)(void);                                         /**< Invoked to restart the device */
     mender_err_t (*get_identity)(mender_identity_t **identity);            /**< Invoked to retrieve identity */
+    mender_err_t (*get_user_provided_keys)(
+        char **user_provided_key, size_t *user_provided_key_length); /**< Invoked to retrieve buffer and buffer size of PEM encoded user-provided key */
 } mender_client_callbacks_t;
 
 /**

--- a/include/mender-tls.h
+++ b/include/mender-tls.h
@@ -42,10 +42,12 @@ mender_err_t mender_tls_init(void);
 
 /**
  * @brief Initialize mender TLS authentication keys
+ * @param callback to get buffer of user provided key
  * @param recommissioning Perform recommissioning (if supported by the platform)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_tls_init_authentication_keys(bool recommissioning);
+mender_err_t mender_tls_init_authentication_keys(mender_err_t (*get_user_provided_keys)(char **user_provided_key, size_t *user_provided_key_length),
+                                                 bool recommissioning);
 
 /**
  * @brief Get public key (PEM format suitable to be integrated in mender authentication request)

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -40,13 +40,23 @@
 /**
  * @brief Mender client options
  */
-static const struct option mender_client_options[] = { { "help", 0, NULL, 'h' },        { "mac_address", 1, NULL, 'm' },  { "artifact_name", 1, NULL, 'a' },
-                                                       { "device_type", 1, NULL, 'd' }, { "tenant_token", 1, NULL, 't' }, { NULL, 0, NULL, 0 } };
+static const struct option mender_client_options[] = { { "help", 0, NULL, 'h' },
+                                                       { "mac_address", 1, NULL, 'm' },
+                                                       { "artifact_name", 1, NULL, 'a' },
+                                                       { "device_type", 1, NULL, 'd' },
+                                                       { "tenant_token", 1, NULL, 't' },
+                                                       { "private_key", 1, NULL, 'p' },
+                                                       { NULL, 0, NULL, 0 } };
 
 /**
  * @brief Mender client identity
  */
 static mender_identity_t mender_identity = { .name = "mac", .value = NULL };
+
+/**
+ * @brief Private key path
+ */
+static char *key_path = NULL;
 
 /**
  * @brief Mender client events
@@ -176,6 +186,43 @@ get_identity_cb(mender_identity_t **identity) {
         return MENDER_OK;
     }
     return MENDER_FAIL;
+}
+
+/**
+ * @brief Get user-provided keys callback
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+static mender_err_t
+get_user_provided_keys_cb(char **user_provided_key, size_t *user_provided_key_length) {
+    if (NULL == key_path) {
+        return MENDER_OK;
+    }
+    mender_log_info("Using key: `%s`", key_path);
+    FILE *file = fopen(key_path, "r");
+    if (NULL == file) {
+        mender_log_error("Unable to open file");
+        return MENDER_FAIL;
+    }
+    fseek(file, 0, SEEK_END);
+    size_t length = ftell(file);
+    fseek(file, 0, SEEK_SET);
+    *user_provided_key = (char *)malloc(length + 1);
+    if (NULL == *user_provided_key) {
+        mender_log_error("Unable to allocate memory");
+        fclose(file);
+        return MENDER_FAIL;
+    }
+    int ret = fread(*user_provided_key, 1, length, file);
+    if (ret != length) {
+        mender_log_error("Unable to read file");
+        fclose(file);
+        return MENDER_FAIL;
+    }
+    fclose(file);
+
+    *user_provided_key_length = length + 1;
+
+    return MENDER_OK;
 }
 
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE
@@ -426,6 +473,7 @@ print_usage(const char *argv0) {
     printf("\t--artifact_name, -a: Artifact name\n");
     printf("\t--device_type, -d: Device type\n");
     printf("\t--tenant_token, -t: Tenant token (optional)\n");
+    printf("\t--private_key, -p: Key path (optional)\n");
 }
 
 /**
@@ -442,6 +490,7 @@ main(int argc, char **argv) {
     char *artifact_name = NULL;
     char *device_type   = NULL;
     char *tenant_token  = NULL;
+    char *private_key   = NULL;
 
     /* Initialize sig handler */
     struct sigaction action;
@@ -476,6 +525,10 @@ main(int argc, char **argv) {
                 /* Tenant token */
                 tenant_token = strdup(optarg);
                 break;
+            case 'p':
+                /* Key path */
+                private_key = strdup(optarg);
+                break;
             default:
                 /* Unknown option */
                 ret = EXIT_FAILURE;
@@ -506,6 +559,9 @@ main(int argc, char **argv) {
         goto END;
     }
 
+    /* Set key path */
+    key_path = private_key;
+
     /* Initialize mender-client */
     mender_identity.value                             = mac_address;
     mender_client_config_t    mender_client_config    = { .artifact_name                = artifact_name,
@@ -521,7 +577,8 @@ main(int argc, char **argv) {
                                                           .authentication_failure = authentication_failure_cb,
                                                           .deployment_status      = deployment_status_cb,
                                                           .restart                = restart_cb,
-                                                          .get_identity           = get_identity_cb };
+                                                          .get_identity           = get_identity_cb,
+                                                          .get_user_provided_keys = get_user_provided_keys_cb };
     if (MENDER_OK != mender_client_init(&mender_client_config, &mender_client_callbacks)) {
         mender_log_error("Unable to initialize mender-client");
         ret = EXIT_FAILURE;
@@ -598,6 +655,7 @@ END:
     if (NULL != tenant_token) {
         free(tenant_token);
     }
+    free(private_key);
 
     return ret;
 }


### PR DESCRIPTION
Accept user provided keys, otherwise generate / get keys from store
Extracted the generation of private key to its own function to make a more generalized function that can create and retrieve a private key.