### PR TITLE
fix: Interpret also `ENOENT` error as not found

### DIFF
--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <errno.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/fs/nvs.h>
 #include <zephyr/storage/flash_map.h>
@@ -52,7 +53,7 @@ nvs_read_alloc(struct nvs_fs *nvs, uint16_t id, void **data, size_t *length) {
     /* Retrieve length of the data */
     ret = nvs_read(nvs, id, NULL, 0);
     if (ret <= 0) {
-        return (0 == ret) ? MENDER_NOT_FOUND : MENDER_FAIL;
+        return (0 == ret || -ENOENT == ret) ? MENDER_NOT_FOUND : MENDER_FAIL;
     }
     *length = (size_t)ret;
 


### PR DESCRIPTION
According to the API docs, `nvs_read` returns the number of bytes read. There is no explicit mention that a return of 0 can be interpret as "not found".

Maybe it worked for some specific platforms if the driver(s) were implemented with this in mind, but generally speaking we should accept also `ENOENT`.