### PR TITLE
Fixed compiler warnings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,5 +46,6 @@ test:smoke-build:
       -DCONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT=OFF
       -DCONFIG_MENDER_FULL_PARSE_ARTIFACT=ON
       -DCONFIG_MENDER_PROVIDES_DEPENDS=ON
+      -DCONFIG_MENDER_ALL_WARNINGS_AS_ERRORS=ON
     - cmake --build build --parallel $(nproc --all)
     - ./build/mender-mcu-client.elf --help

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ cmake_minimum_required(VERSION 3.16.3)
 # Library project
 project(mender-mcu-client LANGUAGES C)
 
+# Compiler options
+if (CONFIG_MENDER_ALL_WARNINGS_AS_ERRORS)
+    add_compile_options(-Wall -Wextra -Werror -Wpointer-arith)
+endif()
+
 # Creation of the library
 add_library(mender-mcu-client STATIC)
 

--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#define _GNU_SOURCE // asprintf
+#include <stdio.h>  // asprintf
+
 #include "mender-api.h"
 #include "mender-artifact.h"
 #include "mender-http.h"

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -553,44 +553,6 @@ mender_artifact_read_manifest(mender_artifact_ctx_t *ctx) {
 }
 
 static mender_err_t
-mender_create_provides_depends_node(const char *type, const char *value, mender_key_value_list_t **provides_depends) {
-
-    assert(NULL != type);
-    assert(NULL != value);
-    assert(NULL != provides_depends);
-
-    mender_key_value_list_t *item = (mender_key_value_list_t *)calloc(1, sizeof(mender_key_value_list_t));
-    if (NULL == item) {
-        mender_log_error("Unable to allocate memory for linked list node");
-        return MENDER_FAIL;
-    }
-
-    item->key = strdup(type);
-    if (NULL == item->key) {
-        mender_log_error("Unable to allocate memory for type");
-        goto ERROR;
-    }
-
-    item->value = strdup(value);
-    if (NULL == item->value) {
-        mender_log_error("Unable to allocate memory for value");
-        goto ERROR;
-    }
-
-    item->next        = *provides_depends;
-    *provides_depends = item;
-
-    return MENDER_OK;
-
-ERROR:
-    free(item->key);
-    free(item->value);
-    free(item);
-
-    return MENDER_FAIL;
-}
-
-static mender_err_t
 mender_artifact_parse_provides_depends(cJSON *json_provides_depends, mender_key_value_list_t **provides_depends) {
 
     assert(NULL != json_provides_depends);

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -505,7 +505,7 @@ mender_artifact_read_manifest(mender_artifact_ctx_t *ctx) {
 
     /* Read data line by line */
     char *line = ctx->input.data;
-    char *end  = ctx->input.data + ctx->input.length;
+    char *end  = line + ctx->input.length;
     while (line < end) {
         char *next = strchr(line, '\n');
         if (NULL == next) {

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -88,7 +88,7 @@ mender_utils_http_status_to_string(int status) {
                  { 511, "Network Authentication Required" } };
 
     /* Return HTTP status as string */
-    for (int index = 0; index < sizeof(desc) / sizeof(desc[0]); index++) {
+    for (size_t index = 0; index < sizeof(desc) / sizeof(desc[0]); index++) {
         if (desc[index].status == status) {
             return desc[index].str;
         }

--- a/platform/tls/generic/mbedtls/src/mender-tls.c
+++ b/platform/tls/generic/mbedtls/src/mender-tls.c
@@ -445,9 +445,11 @@ mender_tls_user_provided_authentication_keys(mbedtls_pk_context *pk_context, con
 
     /* Load and parse the private key buffer */
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    if (0 != (ret = mbedtls_pk_parse_key(pk_context, user_provided_key, user_provided_key_length, NULL, 0, mbedtls_ctr_drbg_random, ctr_drbg))) {
+    if (0
+        != (ret = mbedtls_pk_parse_key(
+                pk_context, (const unsigned char *)user_provided_key, user_provided_key_length, NULL, 0, mbedtls_ctr_drbg_random, ctr_drbg))) {
 #else
-    if (0 != (ret = mbedtls_pk_parse_key(pk_context, user_provided_key, user_provided_key_length, NULL, 0))) {
+    if (0 != (ret = mbedtls_pk_parse_key(pk_context, (const unsigned char *)user_provided_key, user_provided_key_length, NULL, 0))) {
 #endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
         LOG_MBEDTLS_ERROR("Unable to parse private key", ret);
         goto END;


### PR DESCRIPTION
- **fix: compiler warning -Werror=unused-function**
- **fix: compiler warning -Werror=sign-compare**
- **fix: compiler warning -Werror=pointer-sign**
- **fix: compiler warning -Werror=pointer-arith**
- **fix: compiler warning -Werror=implicit-function-declaration**
- **build: added option to enable all warnings as errors**
- **test: enabled all warnings as errors in smoke test**
