### PR TITLE
fix: Workaround I/O errors on some NVS drivers

### DIFF
--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -50,8 +50,9 @@ static mender_err_t
 nvs_read_alloc(struct nvs_fs *nvs, uint16_t id, void **data, size_t *length) {
     ssize_t ret;
 
-    /* Retrieve length of the data */
-    ret = nvs_read(nvs, id, NULL, 0);
+    /* Peek read to retrieve length of the data */
+    uint8_t byte;
+    ret = nvs_read(nvs, id, &byte, 0);
     if (ret <= 0) {
         return (0 == ret || -ENOENT == ret) ? MENDER_NOT_FOUND : MENDER_FAIL;
     }


### PR DESCRIPTION
At least for the ESP driver, a `nvs_read` from a NULL pointer gives I/O error, even when `len` is set to 0. My understanding of the API docs is that it should not be the case, but my painfully slow discovery tells otherwise.

Workaround this by allocating 1 byte first for the peek read.

Changelog: None
Ticket: None