### PR TITLE
fix: fixed error check when reading state

### DIFF
--- a/platform/storage/posix/src/mender-storage.c
+++ b/platform/storage/posix/src/mender-storage.c
@@ -235,7 +235,7 @@ mender_storage_get_update_state(mender_update_state_t *state, char **artifact_ty
     }
     fseek(f, 0, SEEK_SET);
     n_read = fread(state, sizeof(*state), 1, f);
-    if (n_read < sizeof(*state)) {
+    if (n_read < 1) {
         mender_log_error("Failed to read saved update state, ignoring");
         ret = MENDER_FAIL;
         goto END;


### PR DESCRIPTION
On success, `fread()` return the number of items read. This number equals the number of bytes transferred only when size is 1. Hence, we should check that 1 item is read instead of N Bytes.
