### PR TITLE
feat: added deployment data version number and store counter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ file(GLOB SOURCES_TEMP
     "${CMAKE_CURRENT_LIST_DIR}/core/src/mender-client.c"
     "${CMAKE_CURRENT_LIST_DIR}/core/src/mender-utils.c"
     "${CMAKE_CURRENT_LIST_DIR}/core/src/mender-zephyr-image-update-module.c"
+    "${CMAKE_CURRENT_LIST_DIR}/core/src/mender-deployment-data.c"
     "${CMAKE_CURRENT_LIST_DIR}/platform/flash/${CONFIG_MENDER_PLATFORM_FLASH_TYPE}/src/mender-flash.c"
     "${CMAKE_CURRENT_LIST_DIR}/platform/log/${CONFIG_MENDER_PLATFORM_LOG_TYPE}/src/mender-log.c"
     "${CMAKE_CURRENT_LIST_DIR}/platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-http.c"

--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -354,8 +354,7 @@ mender_api_check_for_deployment(mender_api_deployment_data_t *deployment) {
     /* Yes, 404 still means MENDER_OK above */
     if (404 == status) {
         mender_log_debug("POST request to v2 version of the deployments API failed, falling back to v1 version and GET");
-        free(response);
-        response = NULL;
+        FREE_AND_NULL(response);
         if (MENDER_FAIL == (ret = api_check_for_deployment_v1(&status, (void *)&response))) {
             goto END;
         }
@@ -652,10 +651,8 @@ mender_api_exit(void) {
     mender_http_exit();
 
     /* Release memory */
-    free(mender_api_jwt);
-    mender_api_jwt = NULL;
-    free(artifact_name);
-    artifact_name = NULL;
+    FREE_AND_NULL(mender_api_jwt);
+    FREE_AND_NULL(artifact_name);
 
     return MENDER_OK;
 }

--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -214,24 +214,12 @@ END:
 
     /* Release memory */
     free(unformatted_identity);
-    if (NULL != response) {
-        free(response);
-    }
-    if (NULL != signature) {
-        free(signature);
-    }
-    if (NULL != payload) {
-        free(payload);
-    }
-    if (NULL != json_payload) {
-        cJSON_Delete(json_payload);
-    }
-    if (NULL != json_identity) {
-        cJSON_Delete(json_identity);
-    }
-    if (NULL != public_key_pem) {
-        free(public_key_pem);
-    }
+    free(response);
+    free(signature);
+    free(payload);
+    cJSON_Delete(json_payload);
+    cJSON_Delete(json_identity);
+    free(public_key_pem);
 
     return ret;
 }
@@ -455,9 +443,7 @@ mender_api_check_for_deployment(mender_api_deployment_data_t *deployment) {
 END:
 
     /* Release memory */
-    if (NULL != response) {
-        free(response);
-    }
+    free(response);
 
     return ret;
 }
@@ -522,18 +508,10 @@ mender_api_publish_deployment_status(const char *id, mender_deployment_status_t 
 END:
 
     /* Release memory */
-    if (NULL != response) {
-        free(response);
-    }
-    if (NULL != path) {
-        free(path);
-    }
-    if (NULL != payload) {
-        free(payload);
-    }
-    if (NULL != json_payload) {
-        cJSON_Delete(json_payload);
-    }
+    free(response);
+    free(path);
+    free(payload);
+    cJSON_Delete(json_payload);
 
     return ret;
 }
@@ -658,15 +636,9 @@ mender_api_publish_inventory_data(mender_keystore_t *inventory) {
 END:
 
     /* Release memory */
-    if (NULL != response) {
-        free(response);
-    }
-    if (NULL != payload) {
-        free(payload);
-    }
-    if (NULL != object) {
-        cJSON_Delete(object);
-    }
+    free(response);
+    free(payload);
+    cJSON_Delete(object);
 
     return ret;
 }
@@ -680,10 +652,8 @@ mender_api_exit(void) {
     mender_http_exit();
 
     /* Release memory */
-    if (NULL != mender_api_jwt) {
-        free(mender_api_jwt);
-        mender_api_jwt = NULL;
-    }
+    free(mender_api_jwt);
+    mender_api_jwt = NULL;
     free(artifact_name);
     artifact_name = NULL;
 

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -285,17 +285,11 @@ mender_artifact_release_ctx(mender_artifact_ctx_t *ctx) {
 
     /* Release memory */
     if (NULL != ctx) {
-        if (NULL != ctx->input.data) {
-            free(ctx->input.data);
-        }
+        free(ctx->input.data);
         if (NULL != ctx->payloads.values) {
             for (size_t index = 0; index < ctx->payloads.size; index++) {
-                if (NULL != ctx->payloads.values[index].type) {
-                    free(ctx->payloads.values[index].type);
-                }
-                if (NULL != ctx->payloads.values[index].meta_data) {
-                    cJSON_Delete(ctx->payloads.values[index].meta_data);
-                }
+                free(ctx->payloads.values[index].type);
+                cJSON_Delete(ctx->payloads.values[index].meta_data);
 
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
                 mender_utils_free_linked_list(ctx->payloads.values[index].provides);
@@ -308,9 +302,7 @@ mender_artifact_release_ctx(mender_artifact_ctx_t *ctx) {
             }
             free(ctx->payloads.values);
         }
-        if (NULL != ctx->file.name) {
-            free(ctx->file.name);
-        }
+        free(ctx->file.name);
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
         mender_utils_free_linked_list(ctx->artifact_info.provides);
         mender_utils_free_linked_list(ctx->artifact_info.depends);
@@ -472,9 +464,7 @@ mender_artifact_read_version(mender_artifact_ctx_t *ctx) {
 END:
 
     /* Release memory */
-    if (NULL != object) {
-        cJSON_Delete(object);
-    }
+    cJSON_Delete(object);
 
     return ret;
 }
@@ -687,9 +677,7 @@ mender_artifact_read_header_info(mender_artifact_ctx_t *ctx) {
 END:
 
     /* Release memory */
-    if (NULL != object) {
-        cJSON_Delete(object);
-    }
+    cJSON_Delete(object);
 
     return ret;
 }
@@ -781,9 +769,7 @@ mender_artifact_read_type_info(mender_artifact_ctx_t *ctx) {
 END:
 
     /* Release memory */
-    if (NULL != object) {
-        cJSON_Delete(object);
-    }
+    cJSON_Delete(object);
 
     return ret;
 }

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -265,8 +265,7 @@ mender_artifact_process_data(mender_artifact_ctx_t *ctx,
                 if (NULL != substring) {
                     *(substring + strlen(".tar")) = '\0';
                 } else {
-                    free(ctx->file.name);
-                    ctx->file.name = NULL;
+                    FREE_AND_NULL(ctx->file.name);
                 }
                 ctx->file.size  = 0;
                 ctx->file.index = 0;
@@ -343,12 +342,10 @@ mender_artifact_parse_tar_header(mender_artifact_ctx_t *ctx) {
                 if (NULL != substring) {
                     *(substring + strlen(".tar")) = '\0';
                 } else {
-                    free(ctx->file.name);
-                    ctx->file.name = NULL;
+                    FREE_AND_NULL(ctx->file.name);
                 }
             } else {
-                free(ctx->file.name);
-                ctx->file.name = NULL;
+                FREE_AND_NULL(ctx->file.name);
             }
         }
 
@@ -971,8 +968,7 @@ mender_artifact_shift_data(mender_artifact_ctx_t *ctx, size_t length) {
             ctx->input.data = tmp;
             ctx->input.length -= length;
         } else {
-            free(ctx->input.data);
-            ctx->input.data   = NULL;
+            FREE_AND_NULL(ctx->input.data);
             ctx->input.length = 0;
         }
     }

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -27,6 +27,7 @@
 #include "mender-tls.h"
 #include "mender-update-module.h"
 #include "mender-utils.h"
+#include "mender-deployment-data.h"
 
 #ifdef CONFIG_MENDER_CLIENT_INVENTORY
 #include "mender-inventory.h"
@@ -116,9 +117,10 @@ static const char *update_state_str[N_MENDER_UPDATE_STATES + 1] = {
 static bool mender_client_network_connected = false;
 
 /**
- * @brief Deployment data (ID, artifact name and payload types), used to report deployment status after rebooting
+ * @brief Deployment data. Used to track progress of an update, so that the
+ *        operation can resume or roll back across reboots
  */
-static cJSON *mender_client_deployment_data = NULL;
+static mender_deployment_data_t *mender_client_deployment_data = NULL;
 
 /**
  * @brief Mender client update modules list
@@ -445,11 +447,8 @@ mender_client_exit(void) {
     mender_client_config.tenant_token                 = NULL;
     mender_client_config.authentication_poll_interval = 0;
     mender_client_config.update_poll_interval         = 0;
-
-    if (NULL != mender_client_deployment_data) {
-        cJSON_Delete(mender_client_deployment_data);
-        mender_client_deployment_data = NULL;
-    }
+    mender_delete_deployment_data(mender_client_deployment_data);
+    mender_client_deployment_data = NULL;
 
     if (NULL != mender_update_modules_list) {
         for (size_t update_module_index = 0; update_module_index < mender_update_modules_count; update_module_index++) {
@@ -491,8 +490,7 @@ mender_client_work_function(void) {
 static mender_err_t
 mender_client_initialization_work_function(void) {
 
-    char        *storage_deployment_data = NULL;
-    mender_err_t ret                     = MENDER_DONE;
+    mender_err_t ret = MENDER_DONE;
 
     /* Retrieve or generate authentication keys */
     if (MENDER_OK != (ret = mender_tls_init_authentication_keys(mender_client_callbacks.get_user_provided_keys, mender_client_config.recommissioning))) {
@@ -501,21 +499,11 @@ mender_client_initialization_work_function(void) {
     }
 
     /* Retrieve deployment data if it is found (following an update) */
-    if (MENDER_OK != (ret = mender_storage_get_deployment_data(&storage_deployment_data))) {
+    if (MENDER_OK != (ret = mender_get_deployment_data(&mender_client_deployment_data))) {
         if (MENDER_NOT_FOUND != ret) {
             mender_log_error("Unable to get deployment data");
             goto REBOOT;
         }
-    }
-
-    if (NULL != storage_deployment_data) {
-        if (NULL == (mender_client_deployment_data = cJSON_Parse(storage_deployment_data))) {
-            mender_log_error("Unable to parse deployment data");
-            free(storage_deployment_data);
-            ret = MENDER_FAIL;
-            goto REBOOT;
-        }
-        free(storage_deployment_data);
     }
 
     mender_log_info("Initialization done");
@@ -545,13 +533,15 @@ REBOOT:
 static mender_err_t
 mender_commit_artifact_data(void) {
 
-    cJSON *json_artifact_name = cJSON_GetObjectItemCaseSensitive(mender_client_deployment_data, "artifact_name");
-    if (NULL == json_artifact_name) {
+    assert(NULL != mender_client_deployment_data);
+
+    const char *artifact_name;
+    if (MENDER_OK != mender_deployment_data_get_artifact_name(mender_client_deployment_data, &artifact_name)) {
         mender_log_error("Unable to get artifact name from the deployment data");
         return MENDER_FAIL;
     }
 
-    if (MENDER_OK != mender_storage_set_artifact_name(json_artifact_name->valuestring)) {
+    if (MENDER_OK != mender_storage_set_artifact_name(artifact_name)) {
         mender_log_error("Unable to set artifact name");
         return MENDER_FAIL;
     }
@@ -559,15 +549,15 @@ mender_commit_artifact_data(void) {
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
 #ifdef CONFIG_MENDER_PROVIDES_DEPENDS
     /* Get provides from the deployment data */
-    cJSON *provides = cJSON_GetObjectItemCaseSensitive(mender_client_deployment_data, "provides");
-    if (NULL == provides) {
+    const char *provides;
+    if (MENDER_OK != mender_deployment_data_get_provides(mender_client_deployment_data, &provides)) {
         mender_log_error("Unable to get new_provides from the deployment data");
         return MENDER_FAIL;
     }
 
     /* Parse provides */
     mender_key_value_list_t *new_provides = NULL;
-    if (MENDER_OK != mender_utils_string_to_key_value_list(provides->valuestring, &new_provides)) {
+    if (MENDER_OK != mender_utils_string_to_key_value_list(provides, &new_provides)) {
         mender_log_error("Unable to parse provides from the deployment data");
         return MENDER_FAIL;
     }
@@ -878,19 +868,14 @@ mender_client_check_deployment(mender_api_deployment_data_t **deployment_data) {
     /* Create deployment data */
     if (NULL != mender_client_deployment_data) {
         mender_log_warning("Unexpected stale deployment data");
-        cJSON_Delete(mender_client_deployment_data);
+        mender_delete_deployment_data(mender_client_deployment_data);
     }
-    if (NULL == (mender_client_deployment_data = cJSON_CreateObject())) {
-        mender_log_error("Unable to allocate memory");
+    if (MENDER_OK
+        != (mender_create_deployment_data(
+            deployment->id, deployment->artifact_name, NULL /* We will populate later */, NULL /* TODO: MEN-7515 */, &mender_client_deployment_data))) {
+        /* Error already logged */
         return MENDER_FAIL;
     }
-    cJSON_AddStringToObject(mender_client_deployment_data, "id", deployment->id);
-    cJSON_AddStringToObject(mender_client_deployment_data, "artifact_name", deployment->artifact_name);
-    cJSON_AddArrayToObject(mender_client_deployment_data, "types");
-
-    assert(NULL != cJSON_GetObjectItem(mender_client_deployment_data, "id"));
-    assert(NULL != cJSON_GetObjectItem(mender_client_deployment_data, "artifact_name"));
-    assert(NULL != cJSON_GetObjectItem(mender_client_deployment_data, "types"));
 
     return MENDER_OK;
 }
@@ -903,19 +888,15 @@ mender_client_update_work_function(void) {
     mender_artifact_ctx_t *mender_artifact_ctx = NULL;
 
     /* Check for deployment */
-    mender_api_deployment_data_t *deployment              = NULL;
-    char                         *storage_deployment_data = NULL;
-    mender_update_state_t         update_state            = MENDER_UPDATE_STATE_DOWNLOAD;
-    const char                   *deployment_id           = NULL;
+    mender_api_deployment_data_t *deployment    = NULL;
+    mender_update_state_t         update_state  = MENDER_UPDATE_STATE_DOWNLOAD;
+    const char                   *deployment_id = NULL;
 
     /* reset the currently used update module */
     mender_update_module = NULL;
 
-    {
-        cJSON *deployment_id_j = cJSON_GetObjectItem(mender_client_deployment_data, "id");
-        if (NULL != deployment_id_j) {
-            deployment_id = deployment_id_j->valuestring;
-        }
+    if (NULL != mender_client_deployment_data) {
+        mender_deployment_data_get_id(mender_client_deployment_data, &deployment_id);
     }
 
     {
@@ -1001,9 +982,13 @@ mender_client_update_work_function(void) {
                             char       *new_provides  = NULL;
                             const char *artifact_name = NULL;
                             if (MENDER_OK == (ret = mender_prepare_new_provides(mender_artifact_ctx, &new_provides, &artifact_name))) {
-                                cJSON_AddStringToObject(mender_client_deployment_data, "provides", new_provides);
+                                if (MENDER_OK != (ret = mender_deployment_data_set_provides(mender_client_deployment_data, new_provides))) {
+                                    mender_log_error("Failed to set deployment data provides");
+                                }
                                 /* Replace artifact_name with the one from provides */
-                                cJSON_ReplaceItemInObject(mender_client_deployment_data, "artifact_name", cJSON_CreateString(artifact_name));
+                                else if (MENDER_OK != (ret = mender_deployment_data_set_artifact_name(mender_client_deployment_data, artifact_name))) {
+                                    mender_log_error("Failed to set deployment data artifact name");
+                                }
                                 free(new_provides);
                             } else {
                                 mender_log_error("Unable to prepare new provides");
@@ -1047,10 +1032,7 @@ mender_client_update_work_function(void) {
                 mender_client_publish_deployment_status(deployment_id, MENDER_DEPLOYMENT_STATUS_REBOOTING);
 
                 /* Save deployment data to publish deployment status after rebooting */
-                if (NULL == (storage_deployment_data = cJSON_PrintUnformatted(mender_client_deployment_data))) {
-                    mender_log_error("Unable to serialize deployment data for saving");
-                    ret = MENDER_FAIL;
-                } else if (MENDER_OK != (ret = mender_storage_set_deployment_data(storage_deployment_data))) {
+                if (MENDER_OK != (ret = mender_set_deployment_data(mender_client_deployment_data))) {
                     mender_log_error("Unable to save deployment data");
                 }
                 if ((MENDER_OK == ret) && (NULL != mender_update_module->callbacks[update_state])) {
@@ -1168,13 +1150,8 @@ mender_client_update_work_function(void) {
 END:
     /* Release memory */
     deployment_destroy(deployment);
-    if (NULL != storage_deployment_data) {
-        free(storage_deployment_data);
-    }
-    if (NULL != mender_client_deployment_data) {
-        cJSON_Delete(mender_client_deployment_data);
-        mender_client_deployment_data = NULL;
-    }
+    mender_delete_deployment_data(mender_client_deployment_data);
+    mender_client_deployment_data = NULL;
     mender_artifact_release_ctx(mender_artifact_ctx);
 
     return ret;
@@ -1184,7 +1161,6 @@ static mender_err_t
 mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length) {
 
     assert(NULL != type);
-    cJSON       *json_types;
     mender_err_t ret = MENDER_FAIL;
 
 #if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_INF
@@ -1208,30 +1184,21 @@ mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *fil
     }
 
     /* Retrieve ID and artifact name */
-    cJSON *json_id = NULL;
-    if (NULL == (json_id = cJSON_GetObjectItemCaseSensitive(mender_client_deployment_data, "id"))) {
+    const char *id;
+    if (MENDER_OK != mender_deployment_data_get_id(mender_client_deployment_data, &id)) {
         mender_log_error("Unable to get ID from the deployment data");
         goto END;
     }
-    char *id;
-    if (NULL == (id = cJSON_GetStringValue(json_id))) {
-        mender_log_error("Unable to get ID from the deployment data");
-        goto END;
-    }
-    cJSON *json_artifact_name = NULL;
-    if (NULL == (json_artifact_name = cJSON_GetObjectItemCaseSensitive(mender_client_deployment_data, "artifact_name"))) {
-        mender_log_error("Unable to get artifact name from the deployment data");
-        goto END;
-    }
-    char *artifact_name;
-    if (NULL == (artifact_name = cJSON_GetStringValue(json_artifact_name))) {
+    const char *artifact_name;
+    if (MENDER_OK != mender_deployment_data_get_artifact_name(mender_client_deployment_data, &artifact_name)) {
         mender_log_error("Unable to get artifact name from the deployment data");
         goto END;
     }
 
     /* Invoke update module download callback */
-    struct mender_update_download_state_data_s download_state_data = { id, artifact_name, type, meta_data, filename, size, data, index, length, false };
-    mender_update_state_data_t                 state_data          = { .download_state_data = &download_state_data };
+    struct mender_update_download_state_data_s download_state_data
+        = { (char *)id, (char *)artifact_name, type, meta_data, filename, size, data, index, length, false };
+    mender_update_state_data_t state_data = { .download_state_data = &download_state_data };
     if (MENDER_OK != (ret = mender_update_module->callbacks[MENDER_UPDATE_STATE_DOWNLOAD](MENDER_UPDATE_STATE_DOWNLOAD, state_data))) {
         mender_log_error("An error occurred while processing data of the artifact '%s' of type '%s'", artifact_name, type);
         goto END;
@@ -1240,20 +1207,9 @@ mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *fil
     /* Treatments related to the artifact type (once) */
     if (0 == index) {
         /* Add type to the deployment data */
-        if (NULL == (json_types = cJSON_GetObjectItemCaseSensitive(mender_client_deployment_data, "types"))) {
-            mender_log_error("Unable to add type to the deployment data");
-            ret = MENDER_FAIL;
+        if (MENDER_OK != (ret = mender_deployment_data_add_payload_type(mender_client_deployment_data, type))) {
+            /* Error already logged */
             goto END;
-        }
-        bool   found     = false;
-        cJSON *json_type = NULL;
-        cJSON_ArrayForEach(json_type, json_types) {
-            if (StringEqual(type, cJSON_GetStringValue(json_type))) {
-                found = true;
-            }
-        }
-        if (!found) {
-            cJSON_AddItemToArray(json_types, cJSON_CreateString(type));
         }
     }
 

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -1193,9 +1193,8 @@ mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *fil
     }
 
     /* Invoke update module download callback */
-    struct mender_update_download_state_data_s download_state_data
-        = { (char *)id, (char *)artifact_name, type, meta_data, filename, size, data, index, length, false };
-    mender_update_state_data_t state_data = { .download_state_data = &download_state_data };
+    struct mender_update_download_state_data_s download_state_data = { id, artifact_name, type, meta_data, filename, size, data, index, length, false };
+    mender_update_state_data_t                 state_data          = { .download_state_data = &download_state_data };
     if (MENDER_OK != (ret = mender_update_module->callbacks[MENDER_UPDATE_STATE_DOWNLOAD](MENDER_UPDATE_STATE_DOWNLOAD, state_data))) {
         mender_log_error("An error occurred while processing data of the artifact '%s' of type '%s'", artifact_name, type);
         goto END;

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -447,15 +447,13 @@ mender_client_exit(void) {
     mender_client_config.tenant_token                 = NULL;
     mender_client_config.authentication_poll_interval = 0;
     mender_client_config.update_poll_interval         = 0;
-    mender_delete_deployment_data(mender_client_deployment_data);
-    mender_client_deployment_data = NULL;
+    DESTROY_AND_NULL(mender_delete_deployment_data, mender_client_deployment_data);
 
     if (NULL != mender_update_modules_list) {
         for (size_t update_module_index = 0; update_module_index < mender_update_modules_count; update_module_index++) {
             free(mender_update_modules_list[update_module_index]);
         }
-        free(mender_update_modules_list);
-        mender_update_modules_list = NULL;
+        FREE_AND_NULL(mender_update_modules_list);
     }
     mender_update_modules_count = 0;
 
@@ -1150,8 +1148,7 @@ mender_client_update_work_function(void) {
 END:
     /* Release memory */
     deployment_destroy(deployment);
-    mender_delete_deployment_data(mender_client_deployment_data);
-    mender_client_deployment_data = NULL;
+    DESTROY_AND_NULL(mender_delete_deployment_data, mender_client_deployment_data);
     mender_artifact_release_ctx(mender_artifact_ctx);
 
     return ret;

--- a/core/src/mender-deployment-data.c
+++ b/core/src/mender-deployment-data.c
@@ -1,0 +1,311 @@
+/**
+ * @file      mender-deployment-data.c
+ * @brief     Mender Deployment Data interface
+ *
+ * Copyright Northern.tech AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mender-deployment-data.h"
+
+#include "mender-log.h"
+#include "mender-storage.h"
+
+/**
+ * @brief Deployment data version number.
+ * @note cJSON stores numbers as double, so we might as well define this
+ *       constant as a double to avoid type casting.
+ */
+#define DEPLOYMENT_DATA_VERSION 1.0
+
+/**
+ * @brief Deployment data version number.
+ * @note cJSON stores numbers as double, so we might as well define this
+ *       constant as a double to avoid type casting.
+ */
+#define MAX_STATE_DATA_STORE_COUNT 50.0 /* TODO: What should this constant be? */
+
+/**
+ * @brief Validate deployment data
+ * @param deployment_data Deployment data
+ * @return True if valid, otherwise false
+ */
+static bool
+validate_deployment_data(const cJSON *deployment_data) {
+
+    assert(NULL != deployment_data);
+
+    struct key_and_type {
+        const char *const key;
+        cJSON_bool (*type)(const cJSON *const);
+    };
+
+    static const struct key_and_type fields[] = {
+        { .key = MENDER_DEPLOYMENT_DATA_KEY_VERSION, .type = cJSON_IsNumber },                /* So we can modify fields later */
+        { .key = MENDER_DEPLOYMENT_DATA_KEY_ID, .type = cJSON_IsString },                     /* Deployment identifier */
+        { .key = MENDER_DEPLOYMENT_DATA_KEY_ARTIFACT_NAME, .type = cJSON_IsString },          /* Name of artifact */
+        { .key = MENDER_DEPLOYMENT_DATA_KEY_PAYLOAD_TYPES, .type = cJSON_IsArray },           /* Types of payloads embedded in artifact */
+        { .key = MENDER_DEPLOYMENT_DATA_KEY_PROVIDES, .type = cJSON_IsString },               /* Artifact provides (filtered on clears provides) */
+        /* { .key = MENDER_DEPLOYMENT_DATA_KEY_STATE, .type = cJSON_IsString }, */            /* TODO: MEN-7515: State name */
+        { .key = MENDER_DEPLOYMENT_DATA_KEY_STATE_DATA_STORE_COUNT, .type = cJSON_IsNumber }, /* State data store count */
+    };
+
+    const size_t num_fields = sizeof(fields) / sizeof(struct key_and_type);
+    for (size_t i = 0; i < num_fields; i++) {
+        const cJSON *item;
+
+        /* Make sure the field exists */
+        if (NULL == (item = cJSON_GetObjectItemCaseSensitive(deployment_data, fields[i].key))) {
+            mender_log_debug("Missing key '%s' in deployment data", fields[i].key);
+            return false;
+        }
+
+        /* Make sure the field has correct type */
+        if (!fields[i].type(item)) {
+            mender_log_debug("Bad type for key '%s' in deployment data", fields[i].key);
+            return false;
+        }
+
+        /* Check version compatibility */
+        if (StringEqual(fields[i].key, MENDER_DEPLOYMENT_DATA_KEY_VERSION)) {
+            /* Trying to avoid floating-point precision errors */
+            const double delta = (DEPLOYMENT_DATA_VERSION > cJSON_GetNumberValue(item)) ? DEPLOYMENT_DATA_VERSION - cJSON_GetNumberValue(item)
+                                                                                        : cJSON_GetNumberValue(item) - DEPLOYMENT_DATA_VERSION;
+            if (delta > 0.01) {
+                mender_log_debug("Unsupported deployment data version");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+mender_err_t
+mender_set_deployment_data(mender_deployment_data_t *deployment_data) {
+
+    assert(NULL != deployment_data);
+
+    /* Validate deployment data */
+    if (!validate_deployment_data(deployment_data)) {
+        mender_log_error("Invalid deployment data");
+        return MENDER_FAIL;
+    }
+
+    /* Check if max state data store count is reached */
+    cJSON *item = cJSON_GetObjectItemCaseSensitive(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE_DATA_STORE_COUNT);
+    assert(NULL != item); /* Validation above should have catched this already */
+    if (MAX_STATE_DATA_STORE_COUNT <= cJSON_GetNumberValue(item)) {
+        mender_log_error("Reached max state data store count");
+        return MENDER_FAIL;
+    }
+
+    /* Increment state data store count */
+    cJSON_SetNumberValue(item, cJSON_GetNumberValue(item) + 1.0);
+
+    /* Compose JSON string */
+    char *json_str;
+    if (NULL == (json_str = cJSON_PrintUnformatted(deployment_data))) {
+        mender_log_error("Unable to compose deployment data");
+        return MENDER_FAIL;
+    }
+
+    /* Write to store */
+    if (MENDER_OK != mender_storage_set_deployment_data(json_str)) {
+        /* Error already logged */
+        free(json_str);
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
+mender_get_deployment_data(mender_deployment_data_t **deployment_data) {
+
+    assert(NULL != deployment_data);
+
+    mender_err_t ret;
+    char        *json_str;
+
+    if (MENDER_OK != (ret = mender_storage_get_deployment_data(&json_str))) {
+        /* Error already logged */
+        return ret;
+    }
+
+    /* Parse deployment data from JSON string. */
+    *deployment_data = cJSON_Parse(json_str);
+    free(json_str);
+    if (NULL == deployment_data) {
+        mender_log_error("Unable to parse deployment data");
+        return MENDER_FAIL;
+    }
+
+    /* Validate deployment data */
+    if (!validate_deployment_data(*deployment_data)) {
+        mender_log_error("Invalid deployment data");
+        cJSON_Delete(*deployment_data);
+        *deployment_data = NULL;
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
+mender_create_deployment_data(const char *id, const char *artifact_name, const char *provides, const char *name, mender_deployment_data_t **deployment_data) {
+
+    assert(NULL != deployment_data);
+
+    cJSON *item = NULL;
+
+    if (NULL == (*deployment_data = cJSON_CreateObject())) {
+        goto FAIL;
+    }
+
+    /* Add version field */
+    if (NULL == cJSON_AddNumberToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_VERSION, DEPLOYMENT_DATA_VERSION)) {
+        goto FAIL;
+    }
+
+    /* Add deployment ID field */
+    if (NULL == (item = (NULL == id) ? cJSON_CreateNull() : cJSON_CreateString(id))) {
+        goto FAIL;
+    }
+    if (!cJSON_AddItemToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ID, item)) {
+        goto FAIL;
+    }
+    item = NULL;
+
+    /* Add artifact name field */
+    if (NULL == (item = (NULL == artifact_name) ? cJSON_CreateNull() : cJSON_CreateString(artifact_name))) {
+        goto FAIL;
+    }
+    if (!cJSON_AddItemToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ARTIFACT_NAME, item)) {
+        goto FAIL;
+    }
+    item = NULL;
+
+    /* Initialize payload types field as empty array. This one needs to be populated later */
+    if (NULL == cJSON_AddArrayToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_PAYLOAD_TYPES)) {
+        goto FAIL;
+    }
+
+    /* Add provides field */
+    if (NULL == (item = (NULL == provides) ? cJSON_CreateNull() : cJSON_CreateString(provides))) {
+        goto FAIL;
+    }
+    if (!cJSON_AddItemToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_PROVIDES, item)) {
+        goto FAIL;
+    }
+    item = NULL;
+
+    /* Add state name field */
+    if (NULL == (item = (NULL == name) ? cJSON_CreateNull() : cJSON_CreateString(name))) {
+        goto FAIL;
+    }
+    if (!cJSON_AddItemToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE, item)) {
+        goto FAIL;
+    }
+    item = NULL;
+
+    /* Initialize state data store count to zero */
+    if (NULL == (cJSON_AddNumberToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE_DATA_STORE_COUNT, 0.0))) {
+        goto FAIL;
+    }
+
+    return MENDER_OK;
+
+FAIL:
+    /* Only memory allocation errors are possible */
+    mender_log_error("Unable to allocate memory");
+
+    cJSON_Delete(item);
+    cJSON_Delete(*deployment_data);
+    *deployment_data = NULL;
+
+    return MENDER_FAIL;
+}
+
+mender_err_t
+__mender_deployment_data_get_string(const mender_deployment_data_t *deployment_data, const char *key, const char **str) {
+
+    assert(NULL != deployment_data);
+    assert(NULL != key);
+    assert(NULL != str);
+
+    cJSON *item;
+    if (NULL == (item = cJSON_GetObjectItemCaseSensitive(deployment_data, key))) {
+        return MENDER_FAIL;
+    }
+
+    *str = cJSON_GetStringValue(item);
+
+    /* Can hold JSON null, see mender_create_deployment_data() */
+    assert(NULL != *str || cJSON_IsNull(item));
+
+    return MENDER_OK;
+}
+
+mender_err_t
+__mender_deployment_data_set_string(mender_deployment_data_t *deployment_data, const char *key, const char *str) {
+
+    assert(NULL != deployment_data);
+    assert(NULL != key);
+    assert(NULL != str);
+
+    cJSON *item;
+    if (NULL == (item = cJSON_CreateString(str))) {
+        mender_log_error("Unable to allocate memory");
+        return MENDER_FAIL;
+    }
+
+    if (!cJSON_ReplaceItemInObjectCaseSensitive(deployment_data, key, item)) {
+        mender_log_error("Unable to allocate memory");
+        cJSON_Delete(item);
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
+mender_deployment_data_add_payload_type(mender_deployment_data_t *deployment_data, const char *payload_type) {
+
+    assert(NULL != deployment_data);
+    assert(NULL != payload_type);
+
+    cJSON *types;
+    if (NULL == (types = cJSON_GetObjectItemCaseSensitive(deployment_data, "payload_types"))) {
+        return MENDER_FAIL;
+    }
+
+    bool   found = false;
+    cJSON *type  = NULL;
+    cJSON_ArrayForEach(type, types) {
+        if (StringEqual(payload_type, cJSON_GetStringValue(type))) {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        if (!cJSON_AddItemToArray(types, cJSON_CreateString(payload_type))) {
+            mender_log_error("Unable to allocate memory");
+            return MENDER_FAIL;
+        }
+    }
+
+    return MENDER_OK;
+}

--- a/core/src/mender-deployment-data.c
+++ b/core/src/mender-deployment-data.c
@@ -155,8 +155,7 @@ mender_get_deployment_data(mender_deployment_data_t **deployment_data) {
     /* Validate deployment data */
     if (!validate_deployment_data(*deployment_data)) {
         mender_log_error("Invalid deployment data");
-        cJSON_Delete(*deployment_data);
-        *deployment_data = NULL;
+        DESTROY_AND_NULL(cJSON_Delete, *deployment_data);
         return MENDER_FAIL;
     }
 

--- a/core/src/mender-inventory.c
+++ b/core/src/mender-inventory.c
@@ -157,11 +157,9 @@ mender_inventory_exit(void) {
     }
 
     /* Release memory */
-    mender_utils_keystore_delete(mender_inventory_keystore);
-    mender_inventory_keystore = NULL;
+    DESTROY_AND_NULL(mender_utils_keystore_delete, mender_inventory_keystore);
     mender_scheduler_mutex_give(mender_inventory_mutex);
-    mender_scheduler_mutex_delete(mender_inventory_mutex);
-    mender_inventory_mutex = NULL;
+    DESTROY_AND_NULL(mender_scheduler_mutex_delete, mender_inventory_mutex);
 
     return ret;
 }

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -278,14 +278,10 @@ mender_utils_keystore_set_item(mender_keystore_t *keystore, size_t index, char *
     assert(NULL != keystore);
 
     /* Release memory */
-    if (NULL != keystore[index].name) {
-        free(keystore[index].name);
-        keystore[index].name = NULL;
-    }
-    if (NULL != keystore[index].value) {
-        free(keystore[index].value);
-        keystore[index].value = NULL;
-    }
+    free(keystore[index].name);
+    keystore[index].name = NULL;
+    free(keystore[index].value);
+    keystore[index].value = NULL;
 
     /* Copy name and value */
     if (NULL != name) {

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -278,10 +278,8 @@ mender_utils_keystore_set_item(mender_keystore_t *keystore, size_t index, char *
     assert(NULL != keystore);
 
     /* Release memory */
-    free(keystore[index].name);
-    keystore[index].name = NULL;
-    free(keystore[index].value);
-    keystore[index].value = NULL;
+    FREE_AND_NULL(keystore[index].name);
+    FREE_AND_NULL(keystore[index].value);
 
     /* Copy name and value */
     if (NULL != name) {

--- a/include/mender-deployment-data.h
+++ b/include/mender-deployment-data.h
@@ -1,0 +1,174 @@
+/**
+ * @file      mender-deployment-data.h
+ * @brief     Mender Deployment Data interface
+ *
+ * Copyright Northern.tech AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MENDER_DEPLOYMENT_DATA_H__
+#define __MENDER_DEPLOYMENT_DATA_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "mender-utils.h"
+#include "cJSON.h"
+
+#define MENDER_DEPLOYMENT_DATA_KEY_VERSION                "version"
+#define MENDER_DEPLOYMENT_DATA_KEY_ID                     "id"
+#define MENDER_DEPLOYMENT_DATA_KEY_ARTIFACT_NAME          "artifact_name"
+#define MENDER_DEPLOYMENT_DATA_KEY_PAYLOAD_TYPES          "payload_types"
+#define MENDER_DEPLOYMENT_DATA_KEY_PROVIDES               "provides"
+#define MENDER_DEPLOYMENT_DATA_KEY_STATE                  "state"
+#define MENDER_DEPLOYMENT_DATA_KEY_STATE_DATA_STORE_COUNT "state_data_store_count"
+
+typedef cJSON mender_deployment_data_t;
+
+/**
+ * @brief Delete deployment data object
+ * @param deployment_data Deployment data
+ * @note This does not delete it from the store
+ */
+#define mender_delete_deployment_data(deployment_data) cJSON_Delete(deployment_data)
+
+/**
+ * @brief Validate, marshal and write deployment data to store.
+ * @param deployment_data Deployment data
+ * @note Can fail due to invalid deployment data, max store count reached,
+ *       memory allocation errors, or NVS errors.
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+mender_err_t mender_set_deployment_data(mender_deployment_data_t *deployment_data);
+
+/**
+ * @brief Read, unmarshal and validate deployment data from store.
+ * @param deployment_data Deployment data
+ * @return MENDER_OK on success, MENDER_NOT_FOUND if no deployment data
+ *         available, otherwise MENDER_FAIL.
+ */
+mender_err_t mender_get_deployment_data(mender_deployment_data_t **deployment_data);
+
+/**
+ * @brief Create a deployment data object.
+ * @param id Deployment ID or NULL
+ * @param artifact_name Artifact name or NULL
+ * @param provides Provides (filtered on clears provides) or NULL
+ * @param name State name or NULL
+ * @param deployment_data Deployment data
+ * @note The version number field will be initialized to the current version and
+ *       the state data store count field will be initialized to zero. This
+ *       does not take ownership of any of the arguments.
+ * @warning If NULL is passed in the arguments, the respective field will be
+ *          initialized with the JSON 'null' value as a place holder. If you
+ *          don't replace this value before storing the deployment data with
+ *          mender_set_deployment_data(), the validation will fail.
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+mender_err_t mender_create_deployment_data(
+    const char *id, const char *artifact_name, const char *provides, const char *name, mender_deployment_data_t **deployment_data);
+
+/**
+ * @brief Append payload type
+ * @param deployment_data Deployment data
+ * @param payload_type Payload type
+ * @note No operation is done if playload type already exists
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+mender_err_t mender_deployment_data_add_payload_type(mender_deployment_data_t *deployment_data, const char *payload_type);
+
+/**
+ * @warning Do not use this function directly.
+ */
+mender_err_t __mender_deployment_data_get_string(const mender_deployment_data_t *deployment_data, const char *key, const char **str);
+
+/**
+ * @brief Get artifact name
+ * @param deployment_data Deployment data
+ * @param artifact_name Artifact name
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_get_artifact_name(deployment_data, artifact_name) \
+    __mender_deployment_data_get_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ARTIFACT_NAME, artifact_name)
+
+/**
+ * @brief Get provides (filtered on clears provides)
+ * @param deployment_data Deployment data
+ * @param provides Provides
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_get_provides(deployment_data, provides) \
+    __mender_deployment_data_get_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_PROVIDES, provides)
+
+/**
+ * @brief Get deployment ID
+ * @param deployment_data Deployment data
+ * @param id Deployment ID
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_get_id(deployment_data, id) __mender_deployment_data_get_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ID, id)
+
+/**
+ * @brief Get state name
+ * @param deployment_data Deployment data
+ * @param name State name
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_get_state(deployment_data, name) __mender_deployment_data_get_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE, state)
+
+/**
+ * @warning Do not use this function directly.
+ */
+mender_err_t __mender_deployment_data_set_string(mender_deployment_data_t *deployment_data, const char *key, const char *str);
+
+/**
+ * @brief Replace artifact name
+ * @param deployment_data Deployment data
+ * @param artifact_name Artifact name
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_set_artifact_name(deployment_data, artifact_name) \
+    __mender_deployment_data_set_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ARTIFACT_NAME, artifact_name)
+
+/**
+ * @brief Replace provides (filtered on clears provides)
+ * @param deployment_data Deployment data
+ * @param provides Provides
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_set_provides(deployment_data, provides) \
+    __mender_deployment_data_set_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_PROVIDES, provides)
+
+/**
+ * @brief Replace deployment ID
+ * @param deployment_data Deployment data
+ * @param id Deployment ID
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_set_id(deployment_data, id) __mender_deployment_data_set_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ID, id)
+
+/**
+ * @brief Replace state name
+ * @param deployment_data Deployment data
+ * @param name State name
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+#define mender_deployment_data_set_state(deployment_data, name) __mender_deployment_data_set_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE, name)
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __MENDER_DEPLOYMENT_DATA_H__ */

--- a/include/mender-flash.h
+++ b/include/mender-flash.h
@@ -33,7 +33,7 @@ extern "C" {
  * @param handle Handle of the deployment to be used with mender flash functions
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_flash_open(char *name, size_t size, void **handle);
+mender_err_t mender_flash_open(const char *name, size_t size, void **handle);
 
 /**
  * @brief Write deployment data
@@ -43,7 +43,7 @@ mender_err_t mender_flash_open(char *name, size_t size, void **handle);
  * @param length Length of the data to be written
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_flash_write(void *handle, void *data, size_t index, size_t length);
+mender_err_t mender_flash_write(void *handle, const void *data, size_t index, size_t length);
 
 /**
  * @brief Close flash device

--- a/include/mender-update-module.h
+++ b/include/mender-update-module.h
@@ -55,16 +55,16 @@ typedef enum mender_update_state_t {
  * @param length Artifact data length
  */
 struct mender_update_download_state_data_s {
-    char    *id;
-    char    *artifact_name;
-    char    *type;
-    cJSON   *meta_data;
-    char    *filename;
-    size_t   size;
-    uint8_t *data;
-    size_t   offset;
-    size_t   length;
-    bool     done;
+    const char    *id;
+    const char    *artifact_name;
+    const char    *type;
+    const cJSON   *meta_data;
+    const char    *filename;
+    size_t         size;
+    const uint8_t *data;
+    size_t         offset;
+    size_t         length;
+    bool           done;
 };
 
 struct mender_update_install_state_data_s {

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -35,6 +35,18 @@ extern "C" {
 #include <cJSON.h>
 
 /**
+ * @brief Macro for releasing a resource followed by setting it to NULL.
+ */
+#define DESTROY_AND_NULL(destructor, resource) \
+    destructor(resource);                      \
+    resource = NULL
+
+/**
+ * @brief Macro for releasing a resource with free() followed by setting it to NULL.
+ */
+#define FREE_AND_NULL(resource) DESTROY_AND_NULL(free, resource)
+
+/**
  * @brief Macro for comparing two strings
  * @return true if the strings are equal, false otherwise
  */

--- a/platform/flash/posix/src/mender-flash.c
+++ b/platform/flash/posix/src/mender-flash.c
@@ -35,7 +35,7 @@
 #define MENDER_FLASH_REQUEST_UPGRADE CONFIG_MENDER_FLASH_PATH "request_upgrade"
 
 mender_err_t
-mender_flash_open(char *name, size_t size, void **handle) {
+mender_flash_open(const char *name, size_t size, void **handle) {
 
     assert(NULL != name);
     assert(NULL != handle);
@@ -66,7 +66,7 @@ mender_flash_open(char *name, size_t size, void **handle) {
 }
 
 mender_err_t
-mender_flash_write(void *handle, void *data, size_t index, size_t length) {
+mender_flash_write(void *handle, const void *data, size_t index, size_t length) {
 
     (void)index;
 

--- a/platform/flash/zephyr/src/mender-flash.c
+++ b/platform/flash/zephyr/src/mender-flash.c
@@ -24,7 +24,7 @@
 #include "mender-log.h"
 
 mender_err_t
-mender_flash_open(char *name, size_t size, void **handle) {
+mender_flash_open(const char *name, size_t size, void **handle) {
 
     assert(NULL != name);
     assert(NULL != handle);
@@ -49,7 +49,7 @@ mender_flash_open(char *name, size_t size, void **handle) {
 }
 
 mender_err_t
-mender_flash_write(void *handle, void *data, size_t index, size_t length) {
+mender_flash_write(void *handle, const void *data, size_t index, size_t length) {
 
     (void)index;
     int result;

--- a/platform/flash/zephyr/src/mender-flash.c
+++ b/platform/flash/zephyr/src/mender-flash.c
@@ -118,12 +118,8 @@ mender_flash_set_pending_image(void *handle) {
 mender_err_t
 mender_flash_abort_deployment(void *handle) {
 
-    /* Check flash handle */
-    if (NULL != handle) {
-
-        /* Release memory */
-        free(handle);
-    }
+    /* Release memory */
+    free(handle);
 
     return MENDER_OK;
 }

--- a/platform/scheduler/posix/src/mender-scheduler.c
+++ b/platform/scheduler/posix/src/mender-scheduler.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include "mender-log.h"
 #include "mender-scheduler.h"
+#include "mender-utils.h"
 
 /**
  * @brief Default work queue stack size (kB)
@@ -323,8 +324,7 @@ mender_scheduler_mutex_create(void **handle) {
         return MENDER_FAIL;
     }
     if (0 != pthread_mutex_init(*handle, NULL)) {
-        free(*handle);
-        *handle = NULL;
+        FREE_AND_NULL(*handle);
         return MENDER_FAIL;
     }
 

--- a/platform/scheduler/posix/src/mender-scheduler.c
+++ b/platform/scheduler/posix/src/mender-scheduler.c
@@ -178,9 +178,7 @@ FAIL:
     if (NULL != work_context) {
         timer_delete(work_context->timer_handle);
         pthread_mutex_destroy(&work_context->sem_handle);
-        if (NULL != work_context->params.name) {
-            free(work_context->params.name);
-        }
+        free(work_context->params.name);
         free(work_context);
     }
 
@@ -309,9 +307,7 @@ mender_scheduler_work_delete(void *handle) {
     /* Release memory */
     timer_delete(work_context->timer_handle);
     pthread_mutex_destroy(&work_context->sem_handle);
-    if (NULL != work_context->params.name) {
-        free(work_context->params.name);
-    }
+    free(work_context->params.name);
     free(work_context);
 
     return MENDER_OK;

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -25,6 +25,7 @@
 #include <zephyr/kernel.h>
 #include "mender-log.h"
 #include "mender-scheduler.h"
+#include "mender-utils.h"
 
 /**
  * @brief User parameters
@@ -304,8 +305,7 @@ mender_scheduler_mutex_create(void **handle) {
         return MENDER_FAIL;
     }
     if (0 != k_mutex_init((struct k_mutex *)(*handle))) {
-        free(*handle);
-        *handle = NULL;
+        FREE_AND_NULL(*handle);
         return MENDER_FAIL;
     }
 

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -284,16 +284,14 @@ mender_scheduler_work_deactivate(void *handle) {
 mender_err_t
 mender_scheduler_work_delete(void *handle) {
 
-    assert(NULL != handle);
+    if (NULL != handle) {
+        /* Get work context */
+        mender_scheduler_work_context_t *work_context = (mender_scheduler_work_context_t *)handle;
 
-    /* Get work context */
-    mender_scheduler_work_context_t *work_context = (mender_scheduler_work_context_t *)handle;
-
-    /* Release memory */
-    if (NULL != work_context->params.name) {
+        /* Release memory */
         free(work_context->params.name);
+        free(work_context);
     }
-    free(work_context);
 
     return MENDER_OK;
 }
@@ -344,8 +342,6 @@ mender_scheduler_mutex_give(void *handle) {
 
 mender_err_t
 mender_scheduler_mutex_delete(void *handle) {
-
-    assert(NULL != handle);
 
     /* Release memory */
     free(handle);

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -188,9 +188,7 @@ FAIL:
 
     /* Release memory */
     if (NULL != work_context) {
-        if (NULL != work_context->params.name) {
-            free(work_context->params.name);
-        }
+        free(work_context->params.name);
         free(work_context);
     }
 

--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -70,8 +70,7 @@ nvs_read_alloc(struct nvs_fs *nvs, uint16_t id, void **data, size_t *length) {
     /* Read data */
     ret = nvs_read(nvs, id, *data, *length);
     if (ret < 0) {
-        free(*data);
-        *data = NULL;
+        FREE_AND_NULL(*data);
         return MENDER_FAIL;
     }
 
@@ -159,8 +158,7 @@ mender_storage_get_authentication_keys(unsigned char **private_key, size_t *priv
         } else {
             mender_log_error("Unable to read public key");
         }
-        free(*private_key);
-        *private_key = NULL;
+        FREE_AND_NULL(*private_key);
         return ret;
     }
 

--- a/platform/tls/generic/mbedtls/src/mender-tls.c
+++ b/platform/tls/generic/mbedtls/src/mender-tls.c
@@ -32,6 +32,8 @@
 #include "mender-storage.h"
 #include "mender-tls.h"
 
+#include "mender-utils.h"
+
 /**
  * @brief Keys buffer length
  */
@@ -128,11 +130,9 @@ mender_err_t
 mender_tls_init_authentication_keys(mender_err_t (*get_user_provided_keys)(char **user_provided_key, size_t *user_provided_key_length), bool recommissioning) {
 
     /* Release memory */
-    free(mender_tls_private_key);
-    mender_tls_private_key        = NULL;
+    FREE_AND_NULL(mender_tls_private_key);
     mender_tls_private_key_length = 0;
-    free(mender_tls_public_key);
-    mender_tls_public_key        = NULL;
+    FREE_AND_NULL(mender_tls_public_key);
     mender_tls_public_key_length = 0;
 
     /* Check if recommissioning is forced */
@@ -329,8 +329,7 @@ mender_tls_sign_payload(char *payload, char **signature, size_t *signature_lengt
         if (MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL == ret) {
             mender_log_error("This is a bug, please report it");
         }
-        free(*signature);
-        *signature        = NULL;
+        FREE_AND_NULL(*signature);
         *signature_length = 0;
         goto END;
     }
@@ -355,11 +354,9 @@ mender_err_t
 mender_tls_exit(void) {
 
     /* Release memory */
-    free(mender_tls_private_key);
-    mender_tls_private_key        = NULL;
+    FREE_AND_NULL(mender_tls_private_key);
     mender_tls_private_key_length = 0;
-    free(mender_tls_public_key);
-    mender_tls_public_key        = NULL;
+    FREE_AND_NULL(mender_tls_public_key);
     mender_tls_public_key_length = 0;
 
     return MENDER_OK;
@@ -526,17 +523,15 @@ mender_tls_get_authentication_keys(unsigned char **private_key,
     }
     if ((ret = mbedtls_pk_write_key_der(pk_context, *private_key, MENDER_TLS_PRIVATE_KEY_LENGTH)) < 0) {
         LOG_MBEDTLS_ERROR("Unable to write private key to PEM format", ret);
-        free(*private_key);
-        *private_key = NULL;
+        FREE_AND_NULL(*private_key);
         goto END;
     }
     *private_key_length = (size_t)ret;
     memcpy(*private_key, *private_key + MENDER_TLS_PRIVATE_KEY_LENGTH - *private_key_length, *private_key_length);
     if (NULL == (tmp = realloc(*private_key, *private_key_length))) {
         mender_log_error("Unable to allocate memory");
-        free(*private_key);
-        *private_key = NULL;
-        ret          = -1;
+        FREE_AND_NULL(*private_key);
+        ret = -1;
         goto END;
     }
     *private_key = tmp;
@@ -544,28 +539,23 @@ mender_tls_get_authentication_keys(unsigned char **private_key,
     /* Export public key */
     if (NULL == (*public_key = (unsigned char *)malloc(MENDER_TLS_PUBLIC_KEY_LENGTH))) {
         mender_log_error("Unable to allocate memory");
-        free(*private_key);
-        *private_key = NULL;
-        ret          = -1;
+        FREE_AND_NULL(*private_key);
+        ret = -1;
         goto END;
     }
     if ((ret = mbedtls_pk_write_pubkey_der(pk_context, *public_key, MENDER_TLS_PUBLIC_KEY_LENGTH)) < 0) {
         LOG_MBEDTLS_ERROR("Unable to write public key to PEM format", ret);
-        free(*private_key);
-        *private_key = NULL;
-        free(*public_key);
-        *public_key = NULL;
+        FREE_AND_NULL(*private_key);
+        FREE_AND_NULL(*public_key);
         goto END;
     }
     *public_key_length = (size_t)ret;
     memcpy(*public_key, *public_key + MENDER_TLS_PUBLIC_KEY_LENGTH - *public_key_length, *public_key_length);
     if (NULL == (tmp = realloc(*public_key, *public_key_length))) {
         mender_log_error("Unable to allocate memory");
-        free(*private_key);
-        *private_key = NULL;
-        free(*public_key);
-        *public_key = NULL;
-        ret         = -1;
+        FREE_AND_NULL(*private_key);
+        FREE_AND_NULL(*public_key);
+        ret = -1;
         goto END;
     }
     *public_key = tmp;

--- a/platform/tls/generic/mbedtls/src/mender-tls.c
+++ b/platform/tls/generic/mbedtls/src/mender-tls.c
@@ -131,7 +131,6 @@ mender_tls_init_authentication_keys(mender_err_t (*get_user_provided_keys)(char 
     free(mender_tls_private_key);
     mender_tls_private_key        = NULL;
     mender_tls_private_key_length = 0;
-
     free(mender_tls_public_key);
     mender_tls_public_key        = NULL;
     mender_tls_public_key_length = 0;
@@ -339,23 +338,15 @@ mender_tls_sign_payload(char *payload, char **signature, size_t *signature_lengt
 END:
 
     /* Release mbedtls */
-    if (NULL != entropy) {
-        mbedtls_entropy_free(entropy);
-        free(entropy);
-    }
-    if (NULL != ctr_drbg) {
-        mbedtls_ctr_drbg_free(ctr_drbg);
-        free(ctr_drbg);
-    }
-    if (NULL != pk_context) {
-        mbedtls_pk_free(pk_context);
-        free(pk_context);
-    }
+    mbedtls_entropy_free(entropy);
+    free(entropy);
+    mbedtls_ctr_drbg_free(ctr_drbg);
+    free(ctr_drbg);
+    mbedtls_pk_free(pk_context);
+    free(pk_context);
 
     /* Release memory */
-    if (NULL != sig) {
-        free(sig);
-    }
+    free(sig);
 
     return (0 != ret) ? MENDER_FAIL : MENDER_OK;
 }
@@ -364,15 +355,11 @@ mender_err_t
 mender_tls_exit(void) {
 
     /* Release memory */
-    if (NULL != mender_tls_private_key) {
-        free(mender_tls_private_key);
-        mender_tls_private_key = NULL;
-    }
+    free(mender_tls_private_key);
+    mender_tls_private_key        = NULL;
     mender_tls_private_key_length = 0;
-    if (NULL != mender_tls_public_key) {
-        free(mender_tls_public_key);
-        mender_tls_public_key = NULL;
-    }
+    free(mender_tls_public_key);
+    mender_tls_public_key        = NULL;
     mender_tls_public_key_length = 0;
 
     return MENDER_OK;
@@ -432,14 +419,10 @@ mender_tls_generate_authentication_keys(mbedtls_pk_context *pk_context) {
 
 END:
     /* Release mbedtls */
-    if (NULL != entropy) {
-        mbedtls_entropy_free(entropy);
-        free(entropy);
-    }
-    if (NULL != ctr_drbg) {
-        mbedtls_ctr_drbg_free(ctr_drbg);
-        free(ctr_drbg);
-    }
+    mbedtls_entropy_free(entropy);
+    free(entropy);
+    mbedtls_ctr_drbg_free(ctr_drbg);
+    free(ctr_drbg);
 
     return (0 != ret) ? MENDER_FAIL : MENDER_OK;
 }
@@ -488,14 +471,10 @@ mender_tls_user_provided_authentication_keys(mbedtls_pk_context *pk_context, con
 
 END:
     /* Release mbedtls */
-    if (NULL != entropy) {
-        mbedtls_entropy_free(entropy);
-        free(entropy);
-    }
-    if (NULL != ctr_drbg) {
-        mbedtls_ctr_drbg_free(ctr_drbg);
-        free(ctr_drbg);
-    }
+    mbedtls_entropy_free(entropy);
+    free(entropy);
+    mbedtls_ctr_drbg_free(ctr_drbg);
+    free(ctr_drbg);
 
     return (0 != ret) ? MENDER_FAIL : MENDER_OK;
 }
@@ -595,10 +574,8 @@ mender_tls_get_authentication_keys(unsigned char **private_key,
 END:
 
     /* Release mbedtls */
-    if (NULL != pk_context) {
-        mbedtls_pk_free(pk_context);
-        free(pk_context);
-    }
+    mbedtls_pk_free(pk_context);
+    free(pk_context);
 
     return (0 != ret) ? MENDER_FAIL : MENDER_OK;
 }
@@ -682,9 +659,7 @@ mender_tls_pem_write_buffer(const unsigned char *der_data, size_t der_len, char 
 END:
 
     /* Release memory */
-    if (NULL != encode_buf) {
-        free(encode_buf);
-    }
+    free(encode_buf);
 
     return ret;
 }

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -340,15 +340,9 @@ RELEASE:
 END:
 
     /* Release memory */
-    if (NULL != mac_address) {
-        free(mac_address);
-    }
-    if (NULL != device_type) {
-        free(device_type);
-    }
-    if (NULL != tenant_token) {
-        free(tenant_token);
-    }
+    free(mac_address);
+    free(device_type);
+    free(tenant_token);
     free(private_key);
 
     return ret;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -22,6 +22,7 @@ if(CONFIG_MENDER_MCU_CLIENT)
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-artifact.c"
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-client.c"
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-utils.c"
+        "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-deployment-data.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/flash/${CONFIG_MENDER_PLATFORM_FLASH_TYPE}/src/mender-flash.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/log/${CONFIG_MENDER_PLATFORM_LOG_TYPE}/src/mender-log.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-http.c"


### PR DESCRIPTION
- Created deployment data management API.
- Added deployment data version number which allows us to
  add/remove/modify fields in the future.
- Added the deployment data store counter field that prevents infinite
  reboots.
- Deployment data is now validated when reading or writing from store.
- Also did some preparation for adding the update state field later in
  MEN-7515.
