### PR TITLE
feat: Support for two CA certificates

### DIFF
--- a/platform/net/zephyr/src/mender-net.c
+++ b/platform/net/zephyr/src/mender-net.c
@@ -195,9 +195,17 @@ mender_net_connect(const char *host, const char *port) {
 #ifdef CONFIG_NET_SOCKETS_SOCKOPT_TLS
 
     /* Set TLS_SEC_TAG_LIST option */
-    sec_tag_t sec_tag[] = {
-        CONFIG_MENDER_NET_CA_CERTIFICATE_TAG,
+#ifdef CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED
+    sec_tag_t sec_tag[2] = {
+        CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_PRIMARY,
+        CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY,
     };
+#else
+    sec_tag_t sec_tag[1] = {
+        CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_PRIMARY,
+    };
+#endif
+
     if ((result = zsock_setsockopt(sock, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag, sizeof(sec_tag))) < 0) {
         mender_log_error("Unable to set TLS_SEC_TAG_LIST option, result = %d, errno = %d", result, errno);
         goto END;

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -268,11 +268,23 @@ if MENDER_MCU_CLIENT
 
         menu "Network options (ADVANCED)"
 
-            config MENDER_NET_CA_CERTIFICATE_TAG
-                int "CA certificate tag"
+            config MENDER_NET_CA_CERTIFICATE_TAG_PRIMARY
+                int "Primary CA certificate tag for Server"
                 default 1
                 help
-                    A security tag that ROOT CA server credential will be referenced with, see tls_credential_add.
+                    A primary security tag that ROOT CA server credential will be referenced with, typically used to authenicate the Mender Server. See tls_credential_add.
+
+            config MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY
+                int "Secondary CA certificate tag for Artifacts"
+                default 2
+                help
+                    A secondary security tag that ROOT CA server credential will be referenced with, typically used to authenticate the server from where to download Mender Artifacts. See tls_credential_add.
+
+            config MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED
+                bool "Enable MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY"
+                default y
+                help
+                    Enables the secondary CA tag. If this option is enabled, the user must add the two certificates with tls_credential_add
 
             config MENDER_NET_TLS_PEER_VERIFY
                 int "TLS_PEER_VERIFY option"


### PR DESCRIPTION
The secondary is optional, and it is meant for the cases where the Artifacts are downloaded from a different server (or rather, a server that needs a different CA)