### PR TITLE
fix: Keep the flash handle alive after closing

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -1430,7 +1430,6 @@ mender_client_download_artifact_flash_callback(
                 mender_log_error("Unable to close flash handle");
                 goto END;
             }
-            mender_client_flash_handle = NULL;
         }
     }
 


### PR DESCRIPTION
So that the newly flashed image can be marked as `pending` in the install step (which happens _after_ the flashing is completed).

See https://github.com/mendersoftware/mender-mcu/blob/a948a58e7f300ed202b07559cda69e697758330f/core/src/mender-client.c#L1219-L1228

This reverts commit 86a2594c0550f0559360fb40050c90b468fd4172.

The original commit was addressing a segfault in a failure scenario, which we might need to fix independently. This commit at least ensures that "the happy path" works :)