### PR TITLE
Handle unsupported artifact types

### DIFF
--- a/include/mender-storage.h
+++ b/include/mender-storage.h
@@ -90,6 +90,12 @@ mender_err_t mender_storage_save_update_state(mender_update_state_t state, const
 mender_err_t mender_storage_get_update_state(mender_update_state_t *state, char **artifact_type);
 
 /**
+ * @brief Delete update module state
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_storage_delete_update_state(void);
+
+/**
  * @brief Delete deployment data
  * @return MENDER_OK if the function succeeds, error code otherwise
  */

--- a/platform/storage/posix/src/mender-storage.c
+++ b/platform/storage/posix/src/mender-storage.c
@@ -259,6 +259,16 @@ END:
     fclose(f);
     return ret;
 }
+mender_err_t
+mender_storage_delete_update_state(void) {
+    /* Delete update state */
+    if (0 != unlink(MENDER_STORAGE_NVS_UPDATE_STATE)) {
+        mender_log_error("Unable to delete update state");
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
+}
 
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
 #ifdef CONFIG_MENDER_PROVIDES_DEPENDS

--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -225,6 +225,24 @@ mender_storage_delete_deployment_data(void) {
     return MENDER_OK;
 }
 
+mender_err_t
+mender_storage_delete_update_state(void) {
+
+    /* Delete update state */
+    if (0 != nvs_delete(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE)) {
+        mender_log_error("Unable to delete update state");
+        return MENDER_FAIL;
+    }
+
+    /* Delete artifact type */
+    if (0 != nvs_delete(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_ARTIFACT_TYPE)) {
+        mender_log_error("Unable to delete update state");
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
+}
+
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
 #ifdef CONFIG_MENDER_PROVIDES_DEPENDS
 mender_err_t


### PR DESCRIPTION
Handle unsupported artifact types when we 1) load a saved state and 2) when we get a new deployment.