### PR TITLE
chore: Guard definition of `ARG_UNUSED`

### DIFF
--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -43,7 +43,9 @@ extern "C" {
 /**
  * @brief A utility macro to make marking unused arguments less noisy/disruptive
  */
+#ifndef ARG_UNUSED
 #define ARG_UNUSED __attribute__((unused))
+#endif
 
 /**
  * For variables only used in debug builds, in particular only in assert()


### PR DESCRIPTION
Fixes warning in Zephyr builds
```
/home/lluis/west/modules/mender-mcu/zephyr/../include/mender-utils.h:52: warning: "ARG_UNUSED" redefined
```

Previously defined in Zephyr toolchain:
* https://github.com/zephyrproject-rtos/zephyr/blob/v3.7.0/include/zephyr/toolchain/gcc.h#L263