### PR TITLE
fix: Restore mender_save/get_update_state() for Zephyr

### DIFF
--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -323,6 +323,67 @@ mender_storage_get_artifact_name(char **artifact_name) {
 }
 
 mender_err_t
+mender_storage_save_update_state(mender_update_state_t state, const char *artifact_type) {
+    assert(NULL != artifact_type);
+
+    size_t artifact_type_len;
+
+    if (!checked_nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, state, sizeof(state))) {
+        mender_log_error("Unable to save update state");
+        return MENDER_FAIL;
+    }
+
+    artifact_type_size = strlen(artifact_type) + 1;
+    if (!checked_nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_ARTIFACT_TYPE, artifact_type, artifact_type_size)) {
+        mender_log_error("Unable to save update state");
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
+mender_storage_get_update_state(mender_update_state_t *state, char **artifact_type) {
+    assert(NULL != *artifact_type);
+
+    size_t       artifact_type_size;
+    ssize_t      n_read;
+    mender_err_t ret;
+
+    n_read = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, NULL, 0);
+    if (0 == n_read) {
+        mender_log_debug("Update state record empty or unavailable");
+        return MENDER_NOT_FOUND;
+    } else if (n_read < 0) {
+        mender_log_error("Failed to retrieve saved update state");
+        return MENDER_FAIL;
+    }
+
+    n_read = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, state, sizeof(*state));
+    if (n_read < sizeof(*state)) {
+        mender_log_error("Incomplete or invalid update state, ignoring");
+        return MENDER_FAIL;
+    }
+
+    *artifact_type = NULL;
+    ret            = nvs_read_alloc(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_ARTIFACT_TYPE, artifact_type, &artifact_type_size);
+    if (MENDER_OK != ret) {
+        if (MENDER_NOT_FOUND == ret) {
+            mender_log_error("Failed to read saved update state, ignoring");
+            return MENDER_FAIL;
+        }
+    } else {
+        if (artifact_type_size < 2) {
+            mender_log_error("Incomplete or invalid update state, ignoring");
+            free(artifact_type);
+            return MENDER_FAIL;
+        }
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_storage_exit(void) {
 
     /* Nothing to do */

--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -346,12 +346,13 @@ mender_err_t
 mender_storage_get_update_state(mender_update_state_t *state, char **artifact_type) {
     assert(NULL != *artifact_type);
 
-    size_t       artifact_type_size;
-    ssize_t      n_read;
-    mender_err_t ret;
+    size_t        artifact_type_size;
+    ssize_t       n_read;
+    mender_err_t  ret;
+    unsigned char byte;
 
-    n_read = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, NULL, 0);
-    if (0 == n_read) {
+    n_read = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, &byte, 0);
+    if ((0 == n_read) || (-ENOENT == n_read)) {
         mender_log_debug("Update state record empty or unavailable");
         return MENDER_NOT_FOUND;
     } else if (n_read < 0) {


### PR DESCRIPTION
Accidentally removed in de0fab1def36c91e65000727e4d7c251dd09a7b2.