### PR TITLE
fix: Fix (more) platform code for update state storage

### DIFF
--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -346,7 +346,7 @@ mender_storage_save_update_state(mender_update_state_t state, const char *artifa
 
     size_t artifact_type_size;
 
-    if (!checked_nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, (const void *)state, sizeof(state))) {
+    if (!checked_nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_UPDATE_STATE, (const void *)&state, sizeof(state))) {
         mender_log_error("Unable to save update state");
         return MENDER_FAIL;
     }


### PR DESCRIPTION
We need to cast to `void * ` the _address_ of `state`.