### PR TITLE
fix: store state in deployment data

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -868,9 +868,7 @@ mender_client_check_deployment(mender_api_deployment_data_t **deployment_data) {
         mender_log_warning("Unexpected stale deployment data");
         mender_delete_deployment_data(mender_client_deployment_data);
     }
-    if (MENDER_OK
-        != (mender_create_deployment_data(
-            deployment->id, deployment->artifact_name, NULL /* We will populate later */, NULL /* TODO: MEN-7515 */, &mender_client_deployment_data))) {
+    if (MENDER_OK != (mender_create_deployment_data(deployment->id, deployment->artifact_name, &mender_client_deployment_data))) {
         /* Error already logged */
         return MENDER_FAIL;
     }

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -518,7 +518,6 @@ REBOOT:
 
     /* Delete pending deployment */
     mender_storage_delete_deployment_data();
-    mender_storage_delete_update_state();
 
     /* Invoke restart callback, application is responsible to shutdown properly and restart the system */
     if (NULL != mender_client_callbacks.restart) {
@@ -877,6 +876,27 @@ mender_client_check_deployment(mender_api_deployment_data_t **deployment_data) {
 }
 
 static mender_err_t
+set_and_store_state(const mender_update_state_t state) {
+
+    /*
+     * Set the state in `mender_client_deployment_data` and write it to the nvs
+     */
+
+    /* Set state in deployment data */
+    if (MENDER_OK != mender_deployment_data_set_state(mender_client_deployment_data, state)) {
+        mender_log_error("Failed to set deployment data state");
+        return MENDER_FAIL;
+    }
+
+    /* Store deployment data */
+    if (MENDER_OK != mender_set_deployment_data(mender_client_deployment_data)) {
+        mender_log_error("Failed to store deployment data");
+        return MENDER_FAIL;
+    }
+    return MENDER_OK;
+}
+
+static mender_err_t
 mender_client_update_work_function(void) {
     mender_err_t ret = MENDER_OK;
 
@@ -896,9 +916,10 @@ mender_client_update_work_function(void) {
     }
 
     {
-        char                 *artifact_type;
+        const char           *artifact_type;
         mender_update_state_t update_state_resume;
-        if (MENDER_OK == (ret = mender_storage_get_update_state(&update_state_resume, &artifact_type))) {
+        if (MENDER_OK == (ret = mender_deployment_data_get_state(mender_client_deployment_data, &update_state_resume))
+            && MENDER_OK == mender_deployment_data_get_payload_type(mender_client_deployment_data, &artifact_type)) {
             update_state = update_state_resume;
             mender_log_debug("Resuming from state %s", update_state_str[update_state]);
             mender_update_module = mender_client_get_update_module(artifact_type);
@@ -907,11 +928,8 @@ mender_client_update_work_function(void) {
                 mender_log_error("No update module found for artifact type '%s'", artifact_type);
                 mender_client_publish_deployment_status(deployment_id, MENDER_DEPLOYMENT_STATUS_FAILURE);
                 mender_storage_delete_deployment_data();
-                mender_storage_delete_update_state();
-                free(artifact_type);
                 goto END;
             }
-            free(artifact_type);
         }
     }
 
@@ -924,21 +942,21 @@ mender_client_update_work_function(void) {
  *
  * mender_update_module is guaranteed be not NULL since the first
  * successful transition (from the DOWNLOAD state). */
-#define NEXT_STATE                                                                               \
-    if (MENDER_OK == ret) {                                                                      \
-        update_state = update_state_transitions[update_state].success;                           \
-        assert(NULL != mender_update_module);                                                    \
-        mender_log_debug("Entering state %s", update_state_str[update_state]);                   \
-        mender_storage_save_update_state(update_state, mender_update_module->artifact_type);     \
-        ret = MENDER_OK;                                                                         \
-    } else {                                                                                     \
-        update_state = update_state_transitions[update_state].failure;                           \
-        mender_log_debug("Entering state %s", update_state_str[update_state]);                   \
-        if (NULL != mender_update_module) {                                                      \
-            mender_storage_save_update_state(update_state, mender_update_module->artifact_type); \
-        }                                                                                        \
-        ret = MENDER_OK;                                                                         \
-        continue;                                                                                \
+#define NEXT_STATE                                                             \
+    if (MENDER_OK == ret) {                                                    \
+        update_state = update_state_transitions[update_state].success;         \
+        assert(NULL != mender_update_module);                                  \
+        mender_log_debug("Entering state %s", update_state_str[update_state]); \
+        set_and_store_state(update_state);                                     \
+        ret = MENDER_OK;                                                       \
+    } else {                                                                   \
+        update_state = update_state_transitions[update_state].failure;         \
+        mender_log_debug("Entering state %s", update_state_str[update_state]); \
+        if (NULL != mender_update_module) {                                    \
+            set_and_store_state(update_state);                                 \
+        }                                                                      \
+        ret = MENDER_OK;                                                       \
+        continue;                                                              \
     }
 
     while (MENDER_UPDATE_STATE_END != update_state) {
@@ -1015,7 +1033,7 @@ mender_client_update_work_function(void) {
                 if ((MENDER_OK == ret) && !mender_update_module->requires_reboot) {
                     /* skip reboot */
                     update_state = MENDER_UPDATE_STATE_COMMIT;
-                    mender_storage_save_update_state(update_state, mender_update_module->artifact_type);
+                    set_and_store_state(update_state);
                     continue;
                 }
                 /* else continue to the next successful/failure state */
@@ -1026,11 +1044,6 @@ mender_client_update_work_function(void) {
                 assert(mender_update_module->requires_reboot);
                 mender_log_info("Artifact installation done, rebooting");
                 mender_client_publish_deployment_status(deployment_id, MENDER_DEPLOYMENT_STATUS_REBOOTING);
-
-                /* Save deployment data to publish deployment status after rebooting */
-                if (MENDER_OK != (ret = mender_set_deployment_data(mender_client_deployment_data))) {
-                    mender_log_error("Unable to save deployment data");
-                }
                 if ((MENDER_OK == ret) && (NULL != mender_update_module->callbacks[update_state])) {
                     /* Save the next state before running the reboot callback --
                      * if there is an interrupt (power, crash,...) right after,
@@ -1038,9 +1051,8 @@ mender_client_update_work_function(void) {
                      * verification should happen anyway, the callback in that
                      * state should be able to see if things went well or
                      * wrong. */
-                    mender_storage_save_update_state(MENDER_UPDATE_STATE_VERIFY_REBOOT, mender_update_module->artifact_type);
+                    set_and_store_state(MENDER_UPDATE_STATE_VERIFY_REBOOT);
                     ret = mender_update_module->callbacks[update_state](update_state, (mender_update_state_data_t)NULL);
-
                     if (MENDER_OK == ret) {
                         /* now we need to get outside of the loop so that a
                          * potential asynchronous reboot has a chance to kick in
@@ -1087,7 +1099,6 @@ mender_client_update_work_function(void) {
                 }
                 NEXT_STATE;
                 mender_storage_delete_deployment_data();
-                mender_storage_delete_update_state();
                 break; /* below is the failure path */
 
             case MENDER_UPDATE_STATE_ROLLBACK:
@@ -1103,7 +1114,7 @@ mender_client_update_work_function(void) {
             case MENDER_UPDATE_STATE_ROLLBACK_REBOOT:
                 /* Save the next state before running the reboot callback (see
                  * STATE_REBOOT for details). */
-                mender_storage_save_update_state(MENDER_UPDATE_STATE_ROLLBACK_VERIFY_REBOOT, mender_update_module->artifact_type);
+                set_and_store_state(MENDER_UPDATE_STATE_ROLLBACK_VERIFY_REBOOT);
                 ret = mender_update_module->callbacks[update_state](update_state, (mender_update_state_data_t)NULL);
 
                 if (MENDER_OK == ret) {

--- a/core/src/mender-deployment-data.c
+++ b/core/src/mender-deployment-data.c
@@ -163,7 +163,7 @@ mender_get_deployment_data(mender_deployment_data_t **deployment_data) {
 }
 
 mender_err_t
-mender_create_deployment_data(const char *id, const char *artifact_name, const char *provides, const char *name, mender_deployment_data_t **deployment_data) {
+mender_create_deployment_data(const char *id, const char *artifact_name, mender_deployment_data_t **deployment_data) {
 
     assert(NULL != deployment_data);
 
@@ -202,18 +202,14 @@ mender_create_deployment_data(const char *id, const char *artifact_name, const c
     }
 
     /* Add provides field */
-    if (NULL == (item = (NULL == provides) ? cJSON_CreateNull() : cJSON_CreateString(provides))) {
-        goto FAIL;
-    }
+    item = cJSON_CreateNull();
     if (!cJSON_AddItemToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_PROVIDES, item)) {
         goto FAIL;
     }
     item = NULL;
 
-    /* Add state name field */
-    if (NULL == (item = (NULL == name) ? cJSON_CreateNull() : cJSON_CreateString(name))) {
-        goto FAIL;
-    }
+    /* Add state field */
+    item = cJSON_CreateNull();
     if (!cJSON_AddItemToObject(*deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE, item)) {
         goto FAIL;
     }

--- a/include/mender-deployment-data.h
+++ b/include/mender-deployment-data.h
@@ -65,8 +65,6 @@ mender_err_t mender_get_deployment_data(mender_deployment_data_t **deployment_da
  * @brief Create a deployment data object.
  * @param id Deployment ID or NULL
  * @param artifact_name Artifact name or NULL
- * @param provides Provides (filtered on clears provides) or NULL
- * @param name State name or NULL
  * @param deployment_data Deployment data
  * @note The version number field will be initialized to the current version and
  *       the state data store count field will be initialized to zero. This
@@ -77,8 +75,7 @@ mender_err_t mender_get_deployment_data(mender_deployment_data_t **deployment_da
  *          mender_set_deployment_data(), the validation will fail.
  * @return MENDER_OK on success, otherwise MENDER_FAIL
  */
-mender_err_t mender_create_deployment_data(
-    const char *id, const char *artifact_name, const char *provides, const char *name, mender_deployment_data_t **deployment_data);
+mender_err_t mender_create_deployment_data(const char *id, const char *artifact_name, mender_deployment_data_t **deployment_data);
 
 /**
  * @brief Append payload type

--- a/include/mender-deployment-data.h
+++ b/include/mender-deployment-data.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "mender-utils.h"
+#include "mender-update-module.h"
 #include "cJSON.h"
 
 #define MENDER_DEPLOYMENT_DATA_KEY_VERSION                "version"
@@ -69,6 +70,8 @@ mender_err_t mender_get_deployment_data(mender_deployment_data_t **deployment_da
  * @note The version number field will be initialized to the current version and
  *       the state data store count field will be initialized to zero. This
  *       does not take ownership of any of the arguments.
+ *       `Provides` and `state` will be populater later, it's initialized to null
+ *       upon creation.
  * @warning If NULL is passed in the arguments, the respective field will be
  *          initialized with the JSON 'null' value as a place holder. If you
  *          don't replace this value before storing the deployment data with
@@ -85,6 +88,15 @@ mender_err_t mender_create_deployment_data(const char *id, const char *artifact_
  * @return MENDER_OK on success, otherwise MENDER_FAIL
  */
 mender_err_t mender_deployment_data_add_payload_type(mender_deployment_data_t *deployment_data, const char *payload_type);
+
+/**
+ * @brief Get payload type
+ * @param deployment_data Deployment data
+ * @param payload_type Payload type
+ * @note We only support Artifact with 1 payload, so it will always return the first payload from the list
+ * @return MENDER_OK on success, otherwise MENDER_FAIL
+ */
+mender_err_t mender_deployment_data_get_payload_type(const mender_deployment_data_t *deployment_data, const char **payload_type);
 
 /**
  * @warning Do not use this function directly.
@@ -118,12 +130,12 @@ mender_err_t __mender_deployment_data_get_string(const mender_deployment_data_t 
 #define mender_deployment_data_get_id(deployment_data, id) __mender_deployment_data_get_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_ID, id)
 
 /**
- * @brief Get state name
+ * @brief Get state
  * @param deployment_data Deployment data
- * @param name State name
+ * @param state State
  * @return MENDER_OK on success, otherwise MENDER_FAIL
  */
-#define mender_deployment_data_get_state(deployment_data, name) __mender_deployment_data_get_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE, state)
+mender_err_t mender_deployment_data_get_state(mender_deployment_data_t *deployment_data, mender_update_state_t *state);
 
 /**
  * @warning Do not use this function directly.
@@ -162,7 +174,7 @@ mender_err_t __mender_deployment_data_set_string(mender_deployment_data_t *deplo
  * @param name State name
  * @return MENDER_OK on success, otherwise MENDER_FAIL
  */
-#define mender_deployment_data_set_state(deployment_data, name) __mender_deployment_data_set_string(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE, name)
+mender_err_t mender_deployment_data_set_state(mender_deployment_data_t *deployment_data, const mender_update_state_t state);
 
 #ifdef __cplusplus
 }

--- a/include/mender-storage.h
+++ b/include/mender-storage.h
@@ -77,25 +77,6 @@ mender_err_t mender_storage_set_deployment_data(char *deployment_data);
 mender_err_t mender_storage_get_deployment_data(char **deployment_data);
 
 /**
- * @brief Save update module state
- * @param artifact_type artifact type of the update module we are saving the state of
- * @param state state of the update module
- */
-mender_err_t mender_storage_save_update_state(mender_update_state_t state, const char *artifact_type);
-
-/**
- * @brief Get update module state
- * @see mender_storage_save_update_state()
- */
-mender_err_t mender_storage_get_update_state(mender_update_state_t *state, char **artifact_type);
-
-/**
- * @brief Delete update module state
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_storage_delete_update_state(void);
-
-/**
  * @brief Delete deployment data
  * @return MENDER_OK if the function succeeds, error code otherwise
  */

--- a/platform/storage/posix/src/mender-storage.c
+++ b/platform/storage/posix/src/mender-storage.c
@@ -34,7 +34,6 @@
 #define MENDER_STORAGE_NVS_PRIVATE_KEY     CONFIG_MENDER_STORAGE_PATH "key.der"
 #define MENDER_STORAGE_NVS_PUBLIC_KEY      CONFIG_MENDER_STORAGE_PATH "pubkey.der"
 #define MENDER_STORAGE_NVS_DEPLOYMENT_DATA CONFIG_MENDER_STORAGE_PATH "deployment-data.json"
-#define MENDER_STORAGE_NVS_UPDATE_STATE    CONFIG_MENDER_STORAGE_PATH "um_state.dat"
 #define MENDER_STORAGE_NVS_PROVIDES        CONFIG_MENDER_STORAGE_PATH "provides.txt"
 #define MENDER_STORAGE_NVS_ARTICACT_NAME   CONFIG_MENDER_STORAGE_PATH "artifact_name.txt"
 
@@ -178,92 +177,6 @@ mender_storage_delete_deployment_data(void) {
     /* Delete deployment data */
     if (0 != unlink(MENDER_STORAGE_NVS_DEPLOYMENT_DATA)) {
         mender_log_error("Unable to delete deployment data");
-        return MENDER_FAIL;
-    }
-
-    return MENDER_OK;
-}
-
-mender_err_t
-mender_storage_save_update_state(mender_update_state_t state, const char *artifact_type) {
-    assert(NULL != artifact_type);
-    size_t artifact_type_len;
-
-    FILE *f = fopen(MENDER_STORAGE_NVS_UPDATE_STATE, "wb");
-    if (NULL == f) {
-        mender_log_error("Unable to open " MENDER_STORAGE_NVS_UPDATE_STATE " for writing");
-        return MENDER_FAIL;
-    }
-    if (fwrite(&state, 1, sizeof(state), f) != sizeof(state)) {
-        mender_log_error("Unable to save update state");
-        fclose(f);
-        return MENDER_FAIL;
-    }
-    artifact_type_len = strlen(artifact_type);
-    if (fwrite(artifact_type, sizeof(char), artifact_type_len, f) != artifact_type_len) {
-        mender_log_error("Unable to save update state");
-        fclose(f);
-        return MENDER_FAIL;
-    }
-
-    fclose(f);
-    return MENDER_OK;
-}
-
-mender_err_t
-mender_storage_get_update_state(mender_update_state_t *state, char **artifact_type) {
-    FILE        *f;
-    size_t       length;
-    size_t       n_read;
-    mender_err_t ret = MENDER_OK;
-
-    f = fopen(MENDER_STORAGE_NVS_UPDATE_STATE, "rb");
-    if (NULL == f) {
-        mender_log_debug("No update state file");
-        return MENDER_NOT_FOUND;
-    }
-    fseek(f, 0, SEEK_END);
-    length = ftell(f);
-    if (length <= 0) {
-        mender_log_debug("Update state file empty or unavailable");
-        ret = MENDER_NOT_FOUND;
-        goto END;
-    }
-    if (length < (sizeof(*state) + 2)) {
-        mender_log_error("Incomplete or invalid update state, ignoring");
-        ret = MENDER_FAIL;
-        goto END;
-    }
-    fseek(f, 0, SEEK_SET);
-    n_read = fread(state, sizeof(*state), 1, f);
-    if (n_read < 1) {
-        mender_log_error("Failed to read saved update state, ignoring");
-        ret = MENDER_FAIL;
-        goto END;
-    }
-    *artifact_type = calloc(length - sizeof(*state) + 1, sizeof(char));
-    if (NULL == *artifact_type) {
-        mender_log_error("Unable to allocate memory");
-        ret = MENDER_FAIL;
-        goto END;
-    }
-    n_read = fread(*artifact_type, sizeof(char), length - sizeof(*state), f);
-    if (n_read < (length - sizeof(*state))) {
-        mender_log_error("Failed to read saved update state, ignoring");
-        free(*artifact_type);
-        ret = MENDER_FAIL;
-        goto END;
-    }
-
-END:
-    fclose(f);
-    return ret;
-}
-mender_err_t
-mender_storage_delete_update_state(void) {
-    /* Delete update state */
-    if (0 != unlink(MENDER_STORAGE_NVS_UPDATE_STATE)) {
-        mender_log_error("Unable to delete update state");
         return MENDER_FAIL;
     }
 


### PR DESCRIPTION
Removed the key and corresponding functions for storing the update_state
and the artifact type. It is now a part of the deployment data.

Changelog: Title
Ticket: MEN-7515