### PR TITLE
chore: Enable again logging

### DIFF
--- a/platform/log/zephyr/src/mender-log.c
+++ b/platform/log/zephyr/src/mender-log.c
@@ -17,10 +17,6 @@
  * limitations under the License.
  */
 
-#if CONFIG_MENDER_LOG_LEVEL != MENDER_LOG_LEVEL_OFF
-#error This stable branch does not work with Logging. Set CONFIG_MENDER_LOG_LEVEL_OFF=y
-#endif
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mender, CONFIG_MENDER_LOG_LEVEL);
 


### PR DESCRIPTION
To ease developers to further investigate the issues, let's allow logging functionality back in `main`.