### PR TITLE
MEN-7529: Compile `mender-flash.c` only when update module is enabled

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -23,7 +23,6 @@ if(CONFIG_MENDER_MCU_CLIENT)
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-client.c"
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-utils.c"
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-deployment-data.c"
-        "${CMAKE_CURRENT_LIST_DIR}/../platform/flash/${CONFIG_MENDER_PLATFORM_FLASH_TYPE}/src/mender-flash.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/log/${CONFIG_MENDER_PLATFORM_LOG_TYPE}/src/mender-log.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-http.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-net.c"
@@ -36,6 +35,7 @@ if(CONFIG_MENDER_MCU_CLIENT)
     )
     zephyr_library_sources_ifdef(CONFIG_MENDER_ZEPHYR_IMAGE_UPDATE_MODULE
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-zephyr-image-update-module.c"
+        "${CMAKE_CURRENT_LIST_DIR}/../platform/flash/${CONFIG_MENDER_PLATFORM_FLASH_TYPE}/src/mender-flash.c"
     )
     zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../include")
     zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/include")


### PR DESCRIPTION
Only the zephyr-image Update Module makes use of it (plus we have a plan to merge these code bases, see MEN-7554).

Without this fix, we cannot build the project on a board not supporting integration with MCUBoot bootloader.