### PR TITLE
fix: HTTP request timeout

### DIFF
--- a/platform/net/zephyr/src/mender-http.c
+++ b/platform/net/zephyr/src/mender-http.c
@@ -37,7 +37,7 @@
 /**
  * @brief Request timeout (milliseconds)
  */
-#define MENDER_HTTP_REQUEST_TIMEOUT (600 * MSEC_PER_SEC)
+#define MENDER_HTTP_REQUEST_TIMEOUT (60 * 1000)
 
 /**
  * @brief Request context


### PR DESCRIPTION
MSEC_PER_SEC doesn't seem to be defined anywhere. Let's just use good old numbers nad set the timeout to 60 seconds.

Ticket: MEN-7531
Changelog: none