### PR TITLE
Fixed some warnings revealed in static checks

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -795,7 +795,7 @@ mender_client_get_update_module(const char *artifact_type) {
 }
 
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
-mender_err_t
+static mender_err_t
 mender_check_artifact_requirements(mender_artifact_ctx_t *mender_artifact_ctx, mender_api_deployment_data_t *deployment) {
     mender_err_t ret;
 

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -43,7 +43,7 @@ mender_work_function(struct k_work *work) {
     assert(NULL != user_function);
 
     mender_log_debug("Inside work function");
-    mender_err_t status = (*user_function)();
+    MENDER_NDEBUG_UNUSED mender_err_t status = (*user_function)();
     mender_log_debug("Executed work function [%d]", status);
 
     k_work_reschedule(&mender_work_handle, K_SECONDS(user_interval));

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -70,7 +70,7 @@ mender_scheduler_alt_work_create(mender_scheduler_alt_work_function_t func, int3
  * @brief Start work
  */
 mender_err_t
-mender_scheduler_alt_work_start() {
+mender_scheduler_alt_work_start(void) {
 
     assert(NULL != user_function);
 


### PR DESCRIPTION
- **chore: make declaration of symbols static**
- **chore: fixed non-ANSI function declarations**
- **chore: fixed unused variable 'status' in non-debug**
