### PR TITLE
chore: Rework how artifact download is handled

### DIFF
--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -61,16 +61,6 @@ static char *mender_api_jwt = NULL;
 static mender_err_t mender_api_http_text_callback(mender_http_client_event_t event, void *data, size_t data_length, void *params);
 
 /**
- * @brief HTTP callback used to handle artifact content
- * @param event HTTP client event
- * @param data Data received
- * @param data_length Data length
- * @param params Callback parameters
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-static mender_err_t mender_api_http_artifact_callback(mender_http_client_event_t event, void *data, size_t data_length, void *params);
-
-/**
  * @brief Artifact name variable
  */
 static char *artifact_name = NULL;
@@ -516,15 +506,14 @@ END:
 }
 
 mender_err_t
-mender_api_download_artifact(char *uri, mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t)) {
+mender_api_download_artifact(char *uri) {
 
     assert(NULL != uri);
-    assert(NULL != callback);
     mender_err_t ret;
     int          status = 0;
 
     /* Perform HTTP request */
-    if (MENDER_OK != (ret = mender_http_perform(NULL, uri, MENDER_HTTP_GET, NULL, NULL, &mender_api_http_artifact_callback, callback, &status))) {
+    if (MENDER_OK != (ret = mender_http_artifact_download(uri, &status))) {
         mender_log_error("Unable to perform HTTP request");
         goto END;
     }
@@ -705,10 +694,8 @@ mender_api_http_text_callback(mender_http_client_event_t event, void *data, size
     return ret;
 }
 
-static mender_err_t
-mender_api_http_artifact_callback(mender_http_client_event_t event, void *data, size_t data_length, void *params) {
-
-    assert(NULL != params);
+mender_err_t
+mender_api_http_artifact_callback(mender_http_client_event_t event, void *data, size_t data_length) {
     mender_err_t ret = MENDER_OK;
 
     mender_artifact_ctx_t *mender_artifact_ctx = NULL;
@@ -740,7 +727,7 @@ mender_api_http_artifact_callback(mender_http_client_event_t event, void *data, 
             assert(NULL != mender_artifact_ctx);
 
             /* Parse input data */
-            if (MENDER_OK != (ret = mender_artifact_process_data(mender_artifact_ctx, data, data_length, params))) {
+            if (MENDER_OK != (ret = mender_artifact_process_data(mender_artifact_ctx, data, data_length))) {
                 mender_log_error("Unable to process data");
                 break;
             }

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 
 #include "mender-artifact.h"
+#include "mender-client.h"
 #include "mender-log.h"
 
 /**
@@ -120,7 +121,7 @@ static mender_err_t mender_artifact_read_meta_data(mender_artifact_ctx_t *ctx);
  * @param callback Callback function to be invoked to perform the treatment of the data from the artifact
  * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
-static mender_err_t mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t));
+static mender_err_t mender_artifact_read_data(mender_artifact_ctx_t *ctx);
 
 /**
  * @brief Drop content of the current file of the artifact
@@ -194,13 +195,9 @@ is_compressed(const char *filename) {
 }
 
 mender_err_t
-mender_artifact_process_data(mender_artifact_ctx_t *ctx,
-                             void                  *input_data,
-                             size_t                 input_length,
-                             mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t)) {
+mender_artifact_process_data(mender_artifact_ctx_t *ctx, void *input_data, size_t input_length) {
 
     assert(NULL != ctx);
-    assert(NULL != callback);
     mender_err_t ret = MENDER_OK;
     void        *tmp;
 
@@ -264,7 +261,7 @@ mender_artifact_process_data(mender_artifact_ctx_t *ctx,
             } else if (true == mender_utils_strbeginwith(ctx->file.name, "data")) {
 
                 /* Read data */
-                ret = mender_artifact_read_data(ctx, callback);
+                ret = mender_artifact_read_data(ctx);
 
             } else if (false == mender_utils_strendwith(ctx->file.name, ".tar")) {
 
@@ -849,10 +846,9 @@ mender_artifact_read_meta_data(mender_artifact_ctx_t *ctx) {
 }
 
 static mender_err_t
-mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t)) {
+mender_artifact_read_data(mender_artifact_ctx_t *ctx) {
 
     assert(NULL != ctx);
-    assert(NULL != callback);
     mender_err_t ret;
 
     /* Retrieve payload index. We expect "data/%u.tar" where %u is the index.
@@ -884,7 +880,8 @@ mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(c
     if (strlen("data/xxxx.tar") == strlen(ctx->file.name)) {
 
         /* Beginning of the data file */
-        if (MENDER_OK != (ret = callback(ctx->payloads.values[index].type, ctx->payloads.values[index].meta_data, NULL, 0, NULL, 0, 0))) {
+        if (MENDER_OK
+            != (ret = mender_client_download_artifact_callback(ctx->payloads.values[index].type, ctx->payloads.values[index].meta_data, NULL, 0, NULL, 0, 0))) {
             mender_log_error("An error occurred");
             return ret;
         }
@@ -910,15 +907,15 @@ mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(c
         size_t length
             = ((ctx->file.size - ctx->file.index) > MENDER_ARTIFACT_STREAM_BLOCK_SIZE) ? MENDER_ARTIFACT_STREAM_BLOCK_SIZE : (ctx->file.size - ctx->file.index);
 
-        /* Invoke callback */
-        if (MENDER_OK
-            != (ret = callback(ctx->payloads.values[index].type,
-                               ctx->payloads.values[index].meta_data,
-                               strstr(ctx->file.name, ".tar") + strlen(".tar") + 1,
-                               ctx->file.size,
-                               ctx->input.data,
-                               ctx->file.index,
-                               length))) {
+        /* Invoke the download artifact callback */
+        ret = mender_client_download_artifact_callback(ctx->payloads.values[index].type,
+                                                       ctx->payloads.values[index].meta_data,
+                                                       strstr(ctx->file.name, ".tar") + strlen(".tar") + 1,
+                                                       ctx->file.size,
+                                                       ctx->input.data,
+                                                       ctx->file.index,
+                                                       length);
+        if (MENDER_OK != ret) {
             mender_log_error("An error occurred");
             return ret;
         }

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -217,22 +217,6 @@ static mender_err_t mender_check_device_compatibility(mender_artifact_ctx_t *men
 static mender_err_t mender_client_update_work_function(void);
 
 /**
- * @brief Callback function to be invoked to perform the treatment of the data from the artifact
- * @param id ID of the deployment
- * @param artifact name Artifact name
- * @param type Type from header-info payloads
- * @param meta_data Meta-data from header tarball
- * @param filename Artifact filename
- * @param size Artifact file size
- * @param data Artifact data
- * @param index Artifact data index
- * @param length Artifact data length
- * @return MENDER_OK if the function succeeds, error code if an error occurred
- */
-static mender_err_t mender_client_download_artifact_callback(
-    char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length);
-
-/**
  * @brief Publish deployment status of the device to the mender-server and invoke deployment status callback
  * @param id ID of the deployment
  * @param deployment_status Deployment status
@@ -995,7 +979,7 @@ mender_client_update_work_function(void) {
                 /* TODO: the actual update module's download callback is called
                  *       via 9 levels of indirection from here, refactoring
                  *       needed */
-                if (MENDER_OK == (ret = mender_api_download_artifact(deployment->uri, mender_client_download_artifact_callback))) {
+                if (MENDER_OK == (ret = mender_api_download_artifact(deployment->uri))) {
                     assert(NULL != mender_update_module);
 
                     /* Get artifact context if artifact download succeeded */
@@ -1174,7 +1158,7 @@ END:
     return ret;
 }
 
-static mender_err_t
+mender_err_t
 mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length) {
 
     assert(NULL != type);

--- a/include/mender-api.h
+++ b/include/mender-api.h
@@ -25,8 +25,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include "mender-utils.h"
 #include "mender-artifact.h"
+#include "mender-http.h"
+#include "mender-utils.h"
 
 /**
  * @brief Mender API configuration
@@ -84,10 +85,18 @@ mender_err_t mender_api_publish_deployment_status(const char *id, mender_deploym
 /**
  * @brief Download artifact from the mender-server
  * @param uri URI of the deployment received from mender_api_check_for_deployment function
- * @param callback Callback function to be invoked to perform the treatment of the data from the artifact
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_api_download_artifact(char *uri, mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t));
+mender_err_t mender_api_download_artifact(char *uri);
+
+/**
+ * @brief HTTP callback used to handle artifact content
+ * @param event HTTP client event
+ * @param data Data received
+ * @param data_length Data length
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_api_http_artifact_callback(mender_http_client_event_t event, void *data, size_t data_length);
 
 #ifdef CONFIG_MENDER_CLIENT_INVENTORY
 

--- a/include/mender-artifact.h
+++ b/include/mender-artifact.h
@@ -107,10 +107,7 @@ mender_err_t mender_artifact_get_ctx(mender_artifact_ctx_t **ctx);
  * @param callback Callback function to be invoked to perform the treatment of the data from the artifact
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_artifact_process_data(mender_artifact_ctx_t *ctx,
-                                          void                  *input_data,
-                                          size_t                 input_length,
-                                          mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t));
+mender_err_t mender_artifact_process_data(mender_artifact_ctx_t *ctx, void *input_data, size_t input_length);
 
 /**
  * @brief Function used to release artifact context

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -137,6 +137,21 @@ mender_err_t mender_client_ensure_authenticated(void);
  */
 mender_err_t mender_client_exit(void);
 
+/**
+ * @brief Callback function to be invoked to perform the treatment of the data from the artifact
+ * @param id ID of the deployment
+ * @param artifact name Artifact name
+ * @param type Type from header-info payloads
+ * @param meta_data Meta-data from header tarball
+ * @param filename Artifact filename
+ * @param size Artifact file size
+ * @param data Artifact data
+ * @param index Artifact data index
+ * @param length Artifact data length
+ * @return MENDER_OK if the function succeeds, error code if an error occurred
+ */
+mender_err_t mender_client_download_artifact_callback(char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/mender-http.h
+++ b/include/mender-http.h
@@ -82,6 +82,13 @@ mender_err_t mender_http_perform(char                *jwt,
                                  int  *status);
 
 /**
+ * @brief Perform HTTP artifact download request
+ * @param path Path of the request
+ * @param status Status code
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_http_artifact_download(char *path, int *status);
+/**
  * @brief Release mender http
  * @return MENDER_OK if the function succeeds, error code otherwise
  */

--- a/platform/net/zephyr/src/mender-http.c
+++ b/platform/net/zephyr/src/mender-http.c
@@ -20,6 +20,7 @@
 #include <version.h>
 #include <zephyr/net/http/client.h>
 #include <zephyr/kernel.h>
+#include "mender-api.h"
 #include "mender-http.h"
 #include "mender-log.h"
 #include "mender-net.h"
@@ -60,6 +61,14 @@ static mender_http_config_t mender_http_config;
  * @param user_data User data, used to retrieve request context data
  */
 static void mender_http_response_cb(struct http_response *response, enum http_final_call final_call, void *user_data);
+
+/**
+ * @brief HTTP artifact response callback, invoked to handle data received
+ * @param response HTTP response structure
+ * @param final_call Indicate final call
+ * @param user_data User data, used to retrieve request context data
+ */
+static void artifact_response_cb(struct http_response *response, enum http_final_call final_call, void *user_data);
 
 /**
  * @brief Convert mender HTTP method to Zephyr HTTP client method
@@ -232,6 +241,111 @@ END:
 }
 
 mender_err_t
+mender_http_artifact_download(char *path, int *status) {
+
+    assert(NULL != path);
+    assert(NULL != status);
+
+    mender_err_t        ret                = MENDER_FAIL;
+    struct http_request request            = { 0 };
+    mender_err_t        request_ret        = MENDER_OK;
+    const char         *header_fields[3]   = { NULL }; /* The list is NULL terminated; make sure the size reflects it */
+    size_t              header_fields_size = sizeof(header_fields) / sizeof(header_fields[0]);
+    char               *host               = NULL;
+    char               *port               = NULL;
+    char               *url                = NULL;
+    int                 sock               = -1;
+    int                 http_req_ret;
+
+    /* Headers to be added to the request */
+    char *host_header = NULL;
+
+    /* Retrieve host, port and url */
+    if (MENDER_OK != mender_net_get_host_port_url(path, mender_http_config.host, &host, &port, &url)) {
+        mender_log_error("Unable to retrieve host/port/url");
+        goto END;
+    }
+
+    /* Configuration of the client */
+    request.method   = mender_http_method_to_zephyr_http_client_method(MENDER_HTTP_GET);
+    request.url      = url;
+    request.host     = host;
+    request.protocol = "HTTP/1.1";
+    request.response = artifact_response_cb;
+    if (NULL == (request.recv_buf = (uint8_t *)malloc(MENDER_HTTP_RECV_BUF_LENGTH))) {
+        mender_log_error("Unable to allocate memory");
+        goto END;
+    }
+    request.recv_buf_len = MENDER_HTTP_RECV_BUF_LENGTH;
+
+    /* Add headers */
+    host_header = header_alloc_and_add(header_fields, header_fields_size, "Host: %s\r\n", host);
+    if (NULL == host_header) {
+        mender_log_error("Unable to add 'Host' header");
+        goto END;
+    }
+    if (MENDER_FAIL == header_add(header_fields, header_fields_size, MENDER_HEADER_HTTP_USER_AGENT)) {
+        mender_log_error("Unable to add 'User-Agent' header");
+        goto END;
+    }
+    request.header_fields = header_fields;
+
+    /* Connect to the server */
+    sock = mender_net_connect(host, port);
+    if (sock < 0) {
+        mender_log_error("Unable to open HTTP client connection");
+        goto END;
+    }
+    if (MENDER_OK != (ret = mender_api_http_artifact_callback(MENDER_HTTP_EVENT_CONNECTED, NULL, 0))) {
+        mender_log_error("An error occurred while calling 'MENDER_HTTP_EVENT_CONNECTED' artifact callback");
+        goto END;
+    }
+
+    /* Perform HTTP request */
+    if ((http_req_ret = http_client_req(sock, &request, MENDER_HTTP_REQUEST_TIMEOUT, &request_ret)) < 0) {
+        mender_log_error("HTTP request failed: %s", strerror(-http_req_ret));
+        goto END;
+    }
+
+    /* Check if an error occured during the treatment of data */
+    if (MENDER_OK != (ret = request_ret)) {
+        goto END;
+    }
+
+    /* Read HTTP status code */
+    if (0 == request.internal.response.http_status_code) {
+        mender_log_error("An error occurred, connection has been closed");
+        mender_api_http_artifact_callback(MENDER_HTTP_EVENT_ERROR, NULL, 0);
+        goto END;
+    } else {
+        *status = request.internal.response.http_status_code;
+    }
+    if (MENDER_OK != (ret = mender_api_http_artifact_callback(MENDER_HTTP_EVENT_DISCONNECTED, NULL, 0))) {
+        mender_log_error("An error occurred while calling 'MENDER_HTTP_EVENT_DISCONNECTED' artifact callback");
+        goto END;
+    }
+
+    ret = MENDER_OK;
+
+END:
+
+    /* Close connection */
+    if (sock >= 0) {
+        mender_net_disconnect(sock);
+    }
+
+    /* Release memory */
+    free(host);
+    free(port);
+    free(url);
+    free(host_header);
+
+    free(request.recv_buf);
+
+    return ret;
+}
+
+mender_err_t
 mender_http_exit(void) {
 
     /* Nothing to do */
@@ -255,6 +369,25 @@ mender_http_response_cb(struct http_response *response, enum http_final_call fin
         if (MENDER_OK
             != (request_context->ret = request_context->callback(
                     MENDER_HTTP_EVENT_DATA_RECEIVED, (void *)response->body_frag_start, response->body_frag_len, request_context->params))) {
+            mender_log_error("An error occurred, stop reading data");
+        }
+    }
+}
+
+static void
+artifact_response_cb(struct http_response *response, MENDER_ARG_UNUSED enum http_final_call final_call, void *user_data) {
+
+    assert(NULL != response);
+    assert(NULL != user_data);
+
+    /* Retrieve request context */
+    mender_err_t *request_ret = user_data;
+
+    /* Check if data is available */
+    if (response->body_found && (NULL != response->body_frag_start) && (0 != response->body_frag_len) && (MENDER_OK == (*request_ret))) {
+        /* Transmit data received to the upper layer */
+        *request_ret = mender_api_http_artifact_callback(MENDER_HTTP_EVENT_DATA_RECEIVED, (void *)response->body_frag_start, response->body_frag_len);
+        if (MENDER_OK != (*request_ret)) {
             mender_log_error("An error occurred, stop reading data");
         }
     }


### PR DESCRIPTION
In order to avoid passing many callbacks around as arguments and calling the update module's callback 9 levels of nesting deep, we just call the particular functions directly wherever possible. This requires a separate code path tailored to artifact download.

Ticket: MEN-7499
Changelog: none