### PR TITLE
fix: Introduce mender_utils_hexdump_to_bytes() and use it in checksum verification

### DIFF
--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -678,11 +678,9 @@ artifact_read_manifest(mender_artifact_ctx_t *ctx) {
         }
 
         /* Populate with manifest checksum */
-        for (int i = 0; i < MENDER_DIGEST_BUFFER_SIZE; i++) {
-            if (1 != sscanf(checksum_str + (2 * i), "%02hhx", checksum->manifest + i)) {
-                mender_log_error("Bad checksum '%s' in manifest for file '%s'", checksum_str, filename);
-                return MENDER_FAIL;
-            }
+        if (!mender_utils_hexdump_to_bytes(checksum_str, checksum->manifest, MENDER_DIGEST_BUFFER_SIZE)) {
+            mender_log_error("Bad checksum '%s' in manifest for file '%s'", checksum_str, filename);
+            return MENDER_FAIL;
         }
 
         ///* Move to the next line */

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -164,6 +164,29 @@ mender_utils_deployment_status_to_string(mender_deployment_status_t deployment_s
     return NULL;
 }
 
+static inline unsigned char
+hexdigit_value(char digit) {
+    if (digit < 'a') {
+        return digit - '0';
+    } else {
+        return digit - 'a' + 10;
+    }
+}
+
+bool
+mender_utils_hexdump_to_bytes(const char *hexdump, unsigned char *bytes, size_t n_bytes) {
+    for (size_t i = 0; i < n_bytes; i++) {
+        size_t idx = 2 * i;
+        if (!(((hexdump[idx] >= '0') && (hexdump[idx] <= '9')) || ((hexdump[idx] >= 'a') && (hexdump[idx] <= 'f')))
+            || !(((hexdump[idx + 1] >= '0') && (hexdump[idx + 1] <= '9')) || ((hexdump[idx + 1] >= 'a') && (hexdump[idx + 1] <= 'f')))) {
+            mender_log_error("Invalid hex byte: %c%c", hexdump[idx], hexdump[idx + 1]);
+            return false;
+        }
+        bytes[i] = (hexdigit_value(hexdump[idx]) << 4) + hexdigit_value(hexdump[idx + 1]);
+    }
+    return true;
+}
+
 mender_keystore_t *
 mender_utils_keystore_new(size_t length) {
 

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -166,6 +166,16 @@ bool mender_utils_strbeginwith(const char *s1, const char *s2);
 bool mender_utils_strendwith(const char *s1, const char *s2);
 
 /**
+ * @brief Convert a hexdump of bytes into the respective bytes
+ * @param hexdump String containing the hexdumped bytes
+ * @param bytes   An array to store the bytes in
+ * @param n_bytes The number of the bytes to convert (i.e. the size of #bytes and half the
+ *                length of #hexdump).
+ * @return %true if the conversion was successful, false otherwise
+ */
+bool mender_utils_hexdump_to_bytes(const char *hexdump, unsigned char *bytes, size_t n_bytes);
+
+/**
  * @brief Function used to create a key-store
  * @param length Length of the key-store
  * @return Key-store if the function succeeds, NULL otherwise


### PR DESCRIPTION
We have seen sscanf() causing hard failures on real HW, at least on the ESP32-based ones. Let's avoid it in favor of our simple and fast code.

Ticket: MEN-7562
Changelog: none