### PR TITLE
chore: Move variable declaration so that its always initialized at END

### DIFF
--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -216,6 +216,11 @@ api_check_for_deployment_v2(int *status, void *response) {
     mender_err_t ret          = MENDER_FAIL;
     cJSON       *json_payload = NULL;
     char        *payload      = NULL;
+#ifdef CONFIG_MENDER_PROVIDES_DEPENDS
+#ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
+    mender_key_value_list_t *provides = NULL;
+#endif /* CONFIG_MENDER_FULL_PARSE_ARTIFACT */
+#endif /* CONFIG_MENDER_PROVIDES_DEPENDS */
 
     /* Create payload */
     if (NULL == (json_payload = cJSON_CreateObject())) {
@@ -238,7 +243,6 @@ api_check_for_deployment_v2(int *status, void *response) {
 #ifdef CONFIG_MENDER_PROVIDES_DEPENDS
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
     /* Add provides from storage */
-    mender_key_value_list_t *provides = NULL;
     if (MENDER_FAIL == mender_storage_get_provides(&provides)) {
         mender_log_error("Unable to get provides");
         goto END;


### PR DESCRIPTION
Clears `clang` warning:
```
.../mender-api.c:250:9: error: variable 'provides' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]
  250 |     if (NULL == cJSON_AddStringToObject(json_provides, "device_type", mender_api_config.device_type)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/llvm-18/lib/clang/18/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |              ^
.../mender-api.c:302:35: note: uninitialized use occurs here
  302 |     mender_utils_free_linked_list(provides);
      |                                   ^~~~~~~~
.../mender-api.c:250:5: note: remove the 'if' if its condition is always false
  250 |     if (NULL == cJSON_AddStringToObject(json_provides, "device_type", mender_api_config.device_type)) {
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  251 |         mender_log_error("Unable to allocate memory");
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  252 |         goto END;
      |         ~~~~~~~~~
  253 |     }
      |     ~

```