### PR TITLE
MEN-7517: Ensure atomicity/consistency of saved state data

### DIFF
--- a/platform/net/zephyr/src/mender-net.c
+++ b/platform/net/zephyr/src/mender-net.c
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define _GNU_SOURCE //vasprintf
+#include <stdio.h>  //vasprintf
 
 #include <errno.h>
 #include <zephyr/net/socket.h>

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -304,6 +304,12 @@ if MENDER_MCU_CLIENT
                 help
                     Number of sectors of the mender_storage partition, must match the configuration of the partition.
 
+           config MENDER_STORAGE_DEPLOYMENT_DATA_CRC
+                bool "Enable CRC check for deployment data"
+                default y
+                help
+                    Enable CRC check for deployment data, this will add a CRC element to the end of the deployment data, which is verified when the data is read.
+
         endmenu
 
     endif


### PR DESCRIPTION
This is almost the same as just enabling the CRC option, so my only motivation for doing this is that it might be possible that you for some reason don't want a CRC on all the data in the NVS? If that's not a concern, the alternative to this is to simply enable `CONFIG_NVS_DATA_CRC` , which will then write and verify a CRC for all data elements in the nvs.