### PR TITLE
Scheduler rework -- part three, inventory and locking

### DIFF
--- a/core/src/mender-inventory.c
+++ b/core/src/mender-inventory.c
@@ -42,7 +42,7 @@ static void              *mender_inventory_mutex    = NULL;
 /**
  * @brief Mender inventory work handle
  */
-static void *mender_inventory_work_handle = NULL;
+static mender_work_t *mender_inventory_work = NULL;
 
 /**
  * @brief Mender inventory work function
@@ -65,7 +65,7 @@ mender_inventory_init(uint32_t interval) {
     inventory_work_params.function = mender_inventory_work_function;
     inventory_work_params.period   = (0 != interval ? interval : CONFIG_MENDER_CLIENT_INVENTORY_REFRESH_INTERVAL);
     inventory_work_params.name     = "mender_inventory";
-    if (MENDER_OK != (ret = mender_scheduler_work_create(&inventory_work_params, &mender_inventory_work_handle))) {
+    if (MENDER_OK != (ret = mender_scheduler_work_create(&inventory_work_params, &mender_inventory_work))) {
         mender_log_error("Unable to create inventory work");
         return ret;
     }
@@ -79,7 +79,7 @@ mender_inventory_activate(void) {
     mender_err_t ret;
 
     /* Activate inventory work */
-    if (MENDER_OK != (ret = mender_scheduler_work_activate(mender_inventory_work_handle))) {
+    if (MENDER_OK != (ret = mender_scheduler_work_activate(mender_inventory_work))) {
         mender_log_error("Unable to activate inventory work");
         return ret;
     }
@@ -91,7 +91,7 @@ mender_err_t
 mender_inventory_deactivate(void) {
 
     /* Deactivate mender inventory work */
-    mender_scheduler_work_deactivate(mender_inventory_work_handle);
+    mender_scheduler_work_deactivate(mender_inventory_work);
 
     return MENDER_OK;
 }
@@ -133,7 +133,7 @@ mender_inventory_execute(void) {
     mender_err_t ret;
 
     /* Trigger execution of the work */
-    if (MENDER_OK != (ret = mender_scheduler_work_execute(mender_inventory_work_handle))) {
+    if (MENDER_OK != (ret = mender_scheduler_work_execute(mender_inventory_work))) {
         mender_log_error("Unable to trigger inventory work");
         return ret;
     }
@@ -147,8 +147,8 @@ mender_inventory_exit(void) {
     mender_err_t ret;
 
     /* Delete mender inventory work */
-    mender_scheduler_work_delete(mender_inventory_work_handle);
-    mender_inventory_work_handle = NULL;
+    mender_scheduler_work_delete(mender_inventory_work);
+    mender_inventory_work = NULL;
 
     /* Take mutex used to protect access to the inventory key-store */
     if (MENDER_OK != (ret = mender_scheduler_mutex_take(mender_inventory_mutex, -1))) {

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -18,10 +18,6 @@
  * limitations under the License.
  */
 
-#ifdef CONFIG_MENDER_CLIENT_INVENTORY
-#error This stable branch does not work with Inventory
-#endif /* CONFIG_MENDER_CLIENT_INVENTORY */
-
 #include <zephyr/kernel.h>
 #include "mender-log.h"
 #include "mender-scheduler.h"


### PR DESCRIPTION
Based on #105 

Regarding the locking part -- to the best of my knowledge, the only part that needs locking is authentication (and `artifact_name` as @lluiscampos pointed out) which is out of scope of this PR.