### PR TITLE
chore: Shorten the downloading artifact log entry

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -936,10 +936,13 @@ mender_client_update_work_function(void) {
                     goto END;
                 }
 
-                mender_log_info("Downloading deployment artifact with id '%s', artifact name '%s' and uri '%s'",
-                                deployment->id,
-                                deployment->artifact_name,
-                                deployment->uri);
+#if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_INF
+                if (strlen(deployment->id) > 10) {
+                    mender_log_info("Downloading artifact with id '%.7s...', name '%s', uri '%s'", deployment->id, deployment->artifact_name, deployment->uri);
+                } else {
+                    mender_log_info("Downloading artifact with id '%s', name '%s', uri '%s'", deployment->id, deployment->artifact_name, deployment->uri);
+                }
+#endif
                 mender_client_publish_deployment_status(deployment->id, MENDER_DEPLOYMENT_STATUS_DOWNLOADING);
 
                 /* Set deployment_id */


### PR DESCRIPTION
From something like:
```
[00:01:22.304,412] <inf> mender: Downloading deployment artifact with id '5f1aab23-9
629-46e1-b13e-b80033470902', artifact name 'nrf-update-inventory' and uri...
```

To something like:
```
[00:02:33.102,996] <inf> mender: Downloading artifact with id '5cb9365...', name 'nr
f-update-giving', uri 'https://c271964d41749feb10da762816c952ee.r2.cloudf...
```

So that at least part of the uri is visible.