### PR TITLE
chore: Force artifact_name reload on commit

### DIFF
--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -66,6 +66,15 @@ static mender_err_t mender_api_http_text_callback(mender_http_client_event_t eve
 static char *artifact_name = NULL;
 
 mender_err_t
+mender_api_artifact_name_load() {
+    if ((MENDER_OK != mender_storage_get_artifact_name(&artifact_name)) && (NULL != artifact_name)) {
+        mender_log_error("Unable to get artifact name");
+        return MENDER_FAIL;
+    }
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_api_init(mender_api_config_t *config) {
 
     assert(NULL != config);
@@ -74,8 +83,7 @@ mender_api_init(mender_api_config_t *config) {
     mender_err_t ret;
 
     /* Load and set artifact_name here */
-    if ((MENDER_OK != mender_storage_get_artifact_name(&artifact_name)) && (NULL != artifact_name)) {
-        mender_log_error("Unable to get artifact name");
+    if (MENDER_OK != mender_api_artifact_name_load()) {
         return MENDER_FAIL;
     }
     /* Save configuration */

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -485,6 +485,11 @@ mender_commit_artifact_data(void) {
         return MENDER_FAIL;
     }
 
+    if (MENDER_OK != mender_api_artifact_name_load()) {
+        /* Error already logged */
+        return MENDER_FAIL;
+    }
+
 #ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
 #ifdef CONFIG_MENDER_PROVIDES_DEPENDS
     /* Get provides from the deployment data */

--- a/include/mender-api.h
+++ b/include/mender-api.h
@@ -50,6 +50,12 @@ typedef struct {
 } mender_api_deployment_data_t;
 
 /**
+ * @brief Load or re-loads the artifact_name from the persistent store
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_api_artifact_name_load();
+
+/**
  * @brief Initialization of the API
  * @param config Mender API configuration
  * @return MENDER_OK if the function succeeds, error code otherwise


### PR DESCRIPTION
The static variable `artifact_name` from the API source code is used on inventory data push and in deployments check, but it was not being refreshed from the store after a successful commit.