### PR TITLE
chore: Pin the `cjson-zephyr` dependency to the latest commit

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -9,5 +9,4 @@ manifest:
       submodules: true
       remote: mender
       path: modules/lib/cjson
-      # TODO: set to Git sha
-      revision: main
+      revision: aaffa25beabf4df64f8259222af18c1eccbb3315


### PR DESCRIPTION
The module didn't receive updates during these months of development so we can stick to this version for now.