### PR TITLE
fix: fail deployment when it's aborted

### DIFF
--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -600,6 +600,10 @@ mender_api_publish_deployment_status(const char *id, mender_deployment_status_t 
     if (204 == status) {
         /* No response expected */
         ret = MENDER_OK;
+    } else if (409 == status) {
+        /* Deployment aborted */
+        mender_api_print_response_error(response, status);
+        ret = MENDER_ABORTED;
     } else {
         mender_api_print_response_error(response, status);
         ret = MENDER_FAIL;

--- a/core/src/mender-zephyr-image-update-module.c
+++ b/core/src/mender-zephyr-image-update-module.c
@@ -141,7 +141,7 @@ mender_zephyr_image_set_pending_image(MENDER_NDEBUG_UNUSED mender_update_state_t
         return MENDER_FAIL;
     }
 
-    if (MENDER_OK != (ret = mender_flash_set_pending_image(mcu_boot_flash_handle))) {
+    if (MENDER_OK != (ret = mender_flash_set_pending_image(&mcu_boot_flash_handle))) {
         mender_log_error("Unable to set boot partition");
         return ret;
     }
@@ -153,7 +153,7 @@ mender_zephyr_image_abort_deployment(MENDER_NDEBUG_UNUSED mender_update_state_t 
     assert(MENDER_UPDATE_STATE_FAILURE == state);
     mender_err_t ret;
 
-    if (MENDER_OK != (ret = mender_flash_abort_deployment(mcu_boot_flash_handle))) {
+    if (MENDER_OK != (ret = mender_flash_abort_deployment(&mcu_boot_flash_handle))) {
         mender_log_error("Unable to abort deployment");
         return ret;
     }

--- a/include/mender-flash.h
+++ b/include/mender-flash.h
@@ -57,14 +57,14 @@ mender_err_t mender_flash_close(void *handle);
  * @param handle Handle from mender_flash_open
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_flash_set_pending_image(void *handle);
+mender_err_t mender_flash_set_pending_image(void **handle);
 
 /**
  * @brief Abort current deployment
  * @param handle Handle from mender_flash_open
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_flash_abort_deployment(void *handle);
+mender_err_t mender_flash_abort_deployment(void **handle);
 
 /**
  * @brief Mark image valid and cancel rollback if this is still pending

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -93,6 +93,7 @@ typedef enum {
     MENDER_NOT_IMPLEMENTED = -3, /**< Not implemented */
     MENDER_LOOP_DETECTED   = -4, /**< Loop detected */
     MENDER_LOCK_FAILED     = -5, /**< Locking failed */
+    MENDER_ABORTED         = -6, /**< Aborted */
 } mender_err_t;
 
 #define MENDER_IS_ERROR(err_t_ret) ((err_t_ret) < 0)

--- a/platform/flash/generic/weak/src/mender-flash.c
+++ b/platform/flash/generic/weak/src/mender-flash.c
@@ -53,7 +53,7 @@ mender_flash_close(void *handle) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_flash_set_pending_image(void *handle) {
+mender_flash_set_pending_image(void **handle) {
 
     (void)handle;
 
@@ -62,7 +62,7 @@ mender_flash_set_pending_image(void *handle) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_flash_abort_deployment(void *handle) {
+mender_flash_abort_deployment(void **handle) {
 
     (void)handle;
 

--- a/platform/flash/posix/src/mender-flash.c
+++ b/platform/flash/posix/src/mender-flash.c
@@ -101,13 +101,13 @@ mender_flash_close(void *handle) {
 }
 
 mender_err_t
-mender_flash_set_pending_image(void *handle) {
+mender_flash_set_pending_image(void **handle) {
 
     FILE        *file;
     mender_err_t ret = MENDER_OK;
 
     /* Check flash handle */
-    if (NULL != handle) {
+    if (NULL != *handle) {
 
         /* Write request update file */
         if (NULL == (file = fopen(MENDER_FLASH_REQUEST_UPGRADE, "wb"))) {
@@ -122,13 +122,13 @@ mender_flash_set_pending_image(void *handle) {
 }
 
 mender_err_t
-mender_flash_abort_deployment(void *handle) {
+mender_flash_abort_deployment(void **handle) {
 
     /* Check flash handle */
-    if (NULL != handle) {
+    if (NULL != *handle) {
 
         /* Release memory */
-        fclose(handle);
+        fclose(*handle);
     }
 
     return MENDER_OK;

--- a/platform/flash/zephyr/src/mender-flash.c
+++ b/platform/flash/zephyr/src/mender-flash.c
@@ -90,12 +90,12 @@ mender_flash_close(void *handle) {
 }
 
 mender_err_t
-mender_flash_set_pending_image(void *handle) {
+mender_flash_set_pending_image(void **handle) {
 
     int result;
 
     /* Check flash handle */
-    if (NULL != handle) {
+    if (NULL != *handle) {
 
         /* Set new boot partition */
         if (0 != (result = boot_request_upgrade(BOOT_UPGRADE_TEST))) {
@@ -104,7 +104,7 @@ mender_flash_set_pending_image(void *handle) {
         }
 
         /* Release memory */
-        free(handle);
+        FREE_AND_NULL(*handle);
     } else {
 
         /* This should not happen! */
@@ -116,10 +116,10 @@ mender_flash_set_pending_image(void *handle) {
 }
 
 mender_err_t
-mender_flash_abort_deployment(void *handle) {
+mender_flash_abort_deployment(void **handle) {
 
     /* Release memory */
-    free(handle);
+    FREE_AND_NULL(*handle);
 
     return MENDER_OK;
 }

--- a/platform/tls/generic/mbedtls/src/mender-tls.c
+++ b/platform/tls/generic/mbedtls/src/mender-tls.c
@@ -198,6 +198,9 @@ mender_tls_init_authentication_keys(mender_err_t (*get_user_provided_keys)(char 
         case MENDER_LOCK_FAILED:
             assert(false && "Unexpected return value");
             /* fallthrough */
+        case MENDER_ABORTED:
+            assert(false && "Unexpected return value");
+            /* fallthrough */
         case MENDER_FAIL:
             mender_log_error("Unable to get authentication keys from store");
             return MENDER_FAIL;


### PR DESCRIPTION
I didn't know if we wanted to fail on everything except `204`, so I added `MENDER_ABORTED`. If we can go to failure on everything except a `204`, then we could just check for `MENDER_FAIL`
I also added a check to reboot just in case you abort right after the check in install