### PR TITLE
fix: allow compressed files inside a payload

### DIFF
--- a/platform/net/generic/curl/src/mender-http.c
+++ b/platform/net/generic/curl/src/mender-http.c
@@ -309,6 +309,12 @@ mender_http_artifact_download(const char *uri, mender_artifact_download_data_t *
         goto END;
     }
 
+    /* Artifact download failed*/
+    if (MENDER_OK != dl_data->ret) {
+        ret = MENDER_FAIL;
+        goto END;
+    }
+
     /* Read HTTP status code */
     long response_code;
     if (CURLE_OK != (err = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code))) {

--- a/platform/net/zephyr/src/mender-http.c
+++ b/platform/net/zephyr/src/mender-http.c
@@ -304,6 +304,11 @@ mender_http_artifact_download(const char *uri, mender_artifact_download_data_t *
         goto END;
     }
 
+    /* Artifact download failed*/
+    if (MENDER_OK != dl_data->ret) {
+        goto END;
+    }
+
     /* Check if an error occured during the treatment of data */
     if (MENDER_OK != (ret = request_ret)) {
         goto END;


### PR DESCRIPTION
* We don't care if the files _inside_ a payload are compressed, we only want to check for compressed artifacts, i.e. that the payload is not compressed.

* Moved the check to `artifact_read_manifest` to avoid having to call it for every file.

* Check the return value of `artifact_download_callback`

Changelog: Title
Ticket: MEN-7594