### PR TITLE
chore: Use Zephyr logging macros directly

### DIFF
--- a/include/mender-log.h
+++ b/include/mender-log.h
@@ -24,6 +24,10 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#ifdef __ZEPHYR__
+#include <zephyr/logging/log.h>
+#endif /* __ZEPHYR */
+
 #include "mender-utils.h"
 
 /**
@@ -47,6 +51,63 @@ extern "C" {
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_log_init(void);
+
+/**
+ * @brief Release mender log
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_log_exit(void);
+
+#ifdef __ZEPHYR__
+
+LOG_MODULE_DECLARE(mender, CONFIG_MENDER_LOG_LEVEL);
+
+/**
+ * @brief Print error log
+ * @param ... Arguments
+ * @return Error code
+ */
+#if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_ERR
+#define mender_log_error LOG_ERR
+#else
+#define mender_log_error(...)
+#endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_ERR */
+
+/**
+ * @brief Print warning log
+ * @param ... Arguments
+ * @return Error code
+ */
+#if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_WRN
+#define mender_log_warning LOG_WRN
+#else
+#define mender_log_warning(...)
+#endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_WRN */
+
+/**
+ * @brief Print info log
+ * @param ... Arguments
+ * @return Error code
+ */
+#if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_INF
+#define mender_log_info LOG_INF
+#else
+#define mender_log_info(...)
+#endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_INF */
+
+/**
+ * @brief Print debug log
+ * @param error_code Error code
+ * @param ... Arguments
+ * @return Error code
+ */
+#if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_DBG
+#define mender_log_debug LOG_DBG
+#else
+#define mender_log_debug(...)
+#endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_DBG */
+
+#else /* __ZEPHYR__ */
 
 /**
  * @brief Print log
@@ -105,11 +166,7 @@ mender_err_t mender_log_print(uint8_t level, const char *filename, const char *f
 #define mender_log_debug(...)
 #endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_DBG */
 
-/**
- * @brief Release mender log
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_log_exit(void);
+#endif /* __ZEPHYR__ */
 
 #ifdef __cplusplus
 }

--- a/platform/log/zephyr/src/mender-log.c
+++ b/platform/log/zephyr/src/mender-log.c
@@ -18,60 +18,19 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(mender, CONFIG_MENDER_LOG_LEVEL);
 
-#include "mender-log.h"
+/* XXX: Cannot #include <mender-log.h> here because LOG_MODULE_DECLARE() and
+        LOG_MODULE_REGISTER() cannot be present in the same source file
+        (compilation unit).  */
+
+#include <mender-utils.h>
+
+LOG_MODULE_REGISTER(mender, CONFIG_MENDER_LOG_LEVEL);
 
 mender_err_t
 mender_log_init(void) {
 
     /* Nothing to do */
-    return MENDER_OK;
-}
-
-/* IMPORTANT: Please note that the default size of internal Zephyr logger buffer is 1024 bytes; if we need log buffer size 
-              to be more than that there is CONFIG_LOG_BUFFER_SIZE option allowing to extend the buffer size. */
-#define LOG_MESSAGE_MAX_SIZE_BYTES (128)
-
-mender_err_t
-mender_log_print(uint8_t level, const char *filename, const char *function, int line, char *format, ...) {
-
-    (void)filename;
-
-    va_list args;
-    va_start(args, format);
-
-    char log_buff[LOG_MESSAGE_MAX_SIZE_BYTES];
-    int  ret = vsnprintf(log_buff, LOG_MESSAGE_MAX_SIZE_BYTES, format, args);
-
-    va_end(args);
-
-    if (ret < 0) {
-        LOG_ERR("logger error: log message formatting failed: %d", ret);
-        return MENDER_FAIL;
-    } else if (ret >= LOG_MESSAGE_MAX_SIZE_BYTES) {
-        /* Log message is too long; add ... at the end */
-        memset(&log_buff[LOG_MESSAGE_MAX_SIZE_BYTES - 4], '.', 3);
-    }
-
-    /* Switch depending log level */
-    switch (level) {
-        case MENDER_LOG_LEVEL_ERR:
-            LOG_ERR("%s", log_buff);
-            break;
-        case MENDER_LOG_LEVEL_WRN:
-            LOG_WRN("%s", log_buff);
-            break;
-        case MENDER_LOG_LEVEL_INF:
-            LOG_INF("%s", log_buff);
-            break;
-        case MENDER_LOG_LEVEL_DBG:
-            LOG_DBG("%s (%d): %s", function, line, log_buff);
-            break;
-        default:
-            break;
-    }
-
     return MENDER_OK;
 }
 


### PR DESCRIPTION
Zephyr logging is a complex thing that does a lot of magic and optimizations. Using the macros from one place with a single '%s' argument leaves no room for magic. By using the macros directly from various places in our sources and with the various arguments, we give the magic a chance to happen.

#### Note

This makes **zero** difference in how things work (or rather doesn't) on my ESP32-EVB board. The only difference is that I now see the full URL:
```
[00:00:09.878,000] <inf> mender: Downloading artifact with id 'f47ef20...', name 'update56', uri 'https://c271964d41749feb10da762816c952ee.r2.cloudflarestorage.com/mender-artifacts-us/66eaa007a9b44e490044b0f5/d1758124-ab9d-4e8f-b05a-1d511d29826c?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a848c3308d7d52663bbd129dff6a18b7%2F20241122%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241122T123414Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22update56.mender%22&response-content-type=application%2Fvnd.mender-artifact&x-id=GetObject&X-Amz-Signature=04dfcf135a363040852b004034ad7cacb4745447d32bc7a3bc4b1a72ae41defc'
```
(so the changes are applied and "working")