### PR TITLE
fix: Make the mapping in mender_utils_http_status_to_string() static

### DIFF
--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -660,8 +660,7 @@ mender_api_http_text_callback(mender_http_client_event_t event, void *data, size
 
 void
 mender_api_print_response_error(char *response, int status) {
-
-    char *desc;
+    const char *desc;
 
     /* Treatment depending of the status */
     if (NULL != (desc = mender_utils_http_status_to_string(status))) {

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -25,13 +25,13 @@
 /* ASCII record separator */
 #define MENDER_KEY_VALUE_SEPARATOR "\x1E"
 
-char *
+const char *
 mender_utils_http_status_to_string(int status) {
 
     /* Definition of status strings */
-    const struct {
-        uint16_t status;
-        char    *str;
+    static const struct {
+        uint16_t    status;
+        const char *str;
     } desc[] = { { 100, "Continue" },
                  { 101, "Switching Protocols" },
                  { 103, "Early Hints" },

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -137,7 +137,7 @@ typedef struct mender_key_value_list_t {
  * @param status HTTP status code
  * @return HTTP status as string, NULL if it is not found
  */
-char *mender_utils_http_status_to_string(int status);
+const char *mender_utils_http_status_to_string(int status);
 
 /**
  * @brief Function used to print deployment status as string


### PR DESCRIPTION
So that it doesn't end up on the stack.

Also change the type of the `str` field to `const char *` because it always points to string literals.