### PR TITLE
Fix: header.tar checksum calculation in chunks

### DIFF
--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -363,8 +363,11 @@ mender_artifact_process_data(mender_artifact_ctx_t *ctx, void *input_data, size_
             new_size = ctx->input.length + input_length;
             /* data/ files are processed per block for which the original size of the buffer should
                be enough, but metadata is processed as whole files so there we expect we will need
-               more. */
+               more, except for header.tar (and tarballs in general) which are processed
+               transparently. */
             if (mender_utils_strbeginswith(ctx->file.name, "data/")) {
+                expected_required = ctx->input.orig_size;
+            } else if (mender_utils_strendswith(ctx->file.name, ".tar")) {
                 expected_required = ctx->input.orig_size;
             } else {
                 expected_required = artifact_round_up(ctx->file.size, MENDER_ARTIFACT_STREAM_BLOCK_SIZE) + MENDER_ARTIFACT_STREAM_BLOCK_SIZE;


### PR DESCRIPTION
Tested with
```
diff --git a/core/src/mender-artifact.c b/core/src/mender-artifact.c
index c46920c..7c3ae46 100644
--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -304,6 +304,7 @@ mender_artifact_create_ctx(size_t buf_size) {
         mender_log_error("Unable to allocate memory for artifact context");
         return NULL;
     }
+    mender_log_info("Starting with a buffer size of %zd", buf_size);
     if (NULL == (ctx->input.data = malloc(buf_size))) {
         mender_log_error("Unable to allocate memory for artifact context buffer");
         free(ctx);
@@ -360,6 +361,7 @@ mender_artifact_process_data(mender_artifact_ctx_t *ctx, void *input_data, size_
     /* Copy data to the end of the internal buffer */
     if ((NULL != input_data) && (0 != input_length)) {
         if ((ctx->input.length + input_length) > ctx->input.size) {
+            mender_log_error("Current buffer size %zd is too small for %zd", ctx->input.size, (ctx->input.length + input_length));
             new_size = ctx->input.length + input_length;
             /* data/ files are processed per block for which the original size of the buffer should
                be enough, but metadata is processed as whole files so there we expect we will need
```
showing
```
[00:03:00.660,000] <inf> mender: Starting with a buffer size of 1536
```
and nothing else. :partying_face: 