### PR TITLE
chore: set default work queue stack-size to 6 kB #12

### DIFF
--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -276,7 +276,7 @@ if MENDER_MCU_CLIENT
             config MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE
                 int "Mender Scheduler Work Queue Stack Size (kB)"
                 range 0 64
-                default 12
+                default 6
                 depends on MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
                 help
                     Mender scheduler work queue stack size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.


### PR DESCRIPTION
After analyzing the worst-case stack scenarios for all functions on arm using `puncover`, we discovered the highest worst-case stack usage was at 2,328 bytes. Since `puncover` doesn't support xtensa architecture, we estimated the worst-case scenarios for xtensa in two ways: 1) caluclating the average increase in stack sizes of functions from arm
   to xtensa - which was at ~56%
2) getting the max of the increase percentage. Two functions had a 300%
   (8 -> 32 bytes), but considering that is way above average, it made
   more sense to disregard the extreme outliers; the next highest, which had
   quite a few entries, was at 100%

Considering a 100% increase in some functions, the worst case would be around ~4.6 kB in xtensa.

6 kB should therefore be sufficient, as it allows the worst case sizes in arm to grow around 150% on xtensa.

Ticket: MEN-7806