### PR TITLE
ci: set debian frontend to noninteractive

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,7 @@ test:unit:
   stage: test
   image: ubuntu:24.04
   before_script:
+    - export DEBIAN_FRONTEND=noninteractive
     - apt update && apt install -yyq
       cmake git make pkg-config python3
       libcurl4-openssl-dev libcjson-dev


### PR DESCRIPTION
Fixes apt install in the test:static:* jobs