### PR TITLE
fix: Add missing `#include` for sys_reboot() on Zephyr

### DIFF
--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -19,6 +19,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/reboot.h> /* sys_reboot() */
 #include "mender-alloc.h"
 #include "mender-log.h"
 #include "mender-scheduler.h"


### PR DESCRIPTION
Ticket: MEN-7811
Changelog: none