### PR TITLE
chore: Rename mender-scheduler to mender-os and adapt function names

### DIFF
--- a/cmake/mender_mcu_sources.txt
+++ b/cmake/mender_mcu_sources.txt
@@ -140,7 +140,7 @@ file(GLOB MENDER_MCU_SOURCES
     "${MENDER_MCU_ROOT}/platform/log/${CONFIG_MENDER_PLATFORM_LOG_TYPE}/src/mender-log.c"
     "${MENDER_MCU_ROOT}/platform/memory/${CONFIG_MENDER_PLATFORM_MEM_TYPE}/src/mender-alloc.c"
     "${MENDER_MCU_ROOT}/platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-http.c"
-    "${MENDER_MCU_ROOT}/platform/scheduler/${CONFIG_MENDER_PLATFORM_SCHEDULER_TYPE}/src/mender-scheduler.c"
+    "${MENDER_MCU_ROOT}/platform/os/${CONFIG_MENDER_PLATFORM_SCHEDULER_TYPE}/src/mender-os.c"
     "${MENDER_MCU_ROOT}/platform/storage/${CONFIG_MENDER_PLATFORM_STORAGE_TYPE}/src/mender-storage.c"
     "${MENDER_MCU_ROOT}/platform/tls/${CONFIG_MENDER_PLATFORM_TLS_TYPE}/src/mender-tls.c"
     "${MENDER_MCU_ROOT}/platform/sha/${CONFIG_MENDER_PLATFORM_SHA_TYPE}/src/mender-sha.c"

--- a/include/mender-os.h
+++ b/include/mender-os.h
@@ -1,6 +1,6 @@
 /**
- * @file      mender-scheduler.h
- * @brief     Mender scheduler interface
+ * @file      mender-os.h
+ * @brief     Mender OS interface
  *
  * Copyright joelguittet and mender-mcu-client contributors
  * Copyright Northern.tech AS
@@ -18,8 +18,8 @@
  * limitations under the License.
  */
 
-#ifndef __MENDER_SCHEDULER_H__
-#define __MENDER_SCHEDULER_H__
+#ifndef __MENDER_OS_H__
+#define __MENDER_OS_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +34,7 @@ typedef struct {
     mender_err_t (*function)(void); /**< Work function */
     uint32_t period;                /**< Work period (seconds), 0 to disable periodic execution */
     char    *name;                  /**< Work name */
-} mender_scheduler_work_params_t;
+} mender_os_scheduler_work_params_t;
 
 /**
  * @brief Work item
@@ -46,7 +46,7 @@ typedef struct mender_platform_work_t mender_work_t;
  * @brief Initialization of the scheduler
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_init(void);
+mender_err_t mender_os_scheduler_init(void);
 
 /**
  * @brief Function used to register a new work
@@ -54,14 +54,14 @@ mender_err_t mender_scheduler_init(void);
  * @param handle Work handle if the function succeeds, NULL otherwise
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_work_create(mender_scheduler_work_params_t *work_params, mender_work_t **work);
+mender_err_t mender_os_scheduler_work_create(mender_os_scheduler_work_params_t *work_params, mender_work_t **work);
 
 /**
  * @brief Function used to activate a work
  * @param handle Work handle
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_work_activate(mender_work_t *work);
+mender_err_t mender_os_scheduler_work_activate(mender_work_t *work);
 
 /**
  * @brief Function used to set work period
@@ -69,41 +69,41 @@ mender_err_t mender_scheduler_work_activate(mender_work_t *work);
  * @param period Work period (seconds)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_work_set_period(mender_work_t *work, uint32_t period);
+mender_err_t mender_os_scheduler_work_set_period(mender_work_t *work, uint32_t period);
 
 /**
  * @brief Function used to trigger execution of the work
  * @param handle Work handle
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_work_execute(mender_work_t *work);
+mender_err_t mender_os_scheduler_work_execute(mender_work_t *work);
 
 /**
  * @brief Function used to deactivate a work
  * @param handle Work handle
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_work_deactivate(mender_work_t *work);
+mender_err_t mender_os_scheduler_work_deactivate(mender_work_t *work);
 
 /**
  * @brief Function used to delete a work
  * @param handle Work handle
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_work_delete(mender_work_t *work);
+mender_err_t mender_os_scheduler_work_delete(mender_work_t *work);
 
 /**
  * @brief Release mender scheduler
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_exit(void);
+mender_err_t mender_os_scheduler_exit(void);
 
 /**
  * @brief Function used to create a mutex
  * @param handle Mutex handle if the function succeeds, NULL otherwise
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_mutex_create(void **handle);
+mender_err_t mender_os_mutex_create(void **handle);
 
 /**
  * @brief Function used to take a mutex
@@ -111,29 +111,29 @@ mender_err_t mender_scheduler_mutex_create(void **handle);
  * @param delay_ms Delay to obtain the mutex, -1 to block indefinitely (without a timeout)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_mutex_take(void *handle, int32_t delay_ms);
+mender_err_t mender_os_mutex_take(void *handle, int32_t delay_ms);
 
 /**
  * @brief Function used to give a mutex
  * @param handle Mutex handle
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_mutex_give(void *handle);
+mender_err_t mender_os_mutex_give(void *handle);
 
 /**
  * @brief Function used to delete a mutex
  * @param handle Mutex handle
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_scheduler_mutex_delete(void *handle);
+mender_err_t mender_os_mutex_delete(void *handle);
 
 /**
  * @brief Unconditionally reboot the system (e.g. if the reboot callback fails to do so)
  */
-void mender_scheduler_reboot(void);
+void mender_os_reboot(void);
 
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
 
-#endif /* __MENDER_SCHEDULER_H__ */
+#endif /* __MENDER_OS_H__ */

--- a/platform/os/generic/weak/src/mender-os.c
+++ b/platform/os/generic/weak/src/mender-os.c
@@ -1,6 +1,6 @@
 /**
- * @file      mender-scheduler.c
- * @brief     Mender scheduler interface for weak platform
+ * @file      mender-os.c
+ * @brief     Mender OS interface for weak platform
  *
  * Copyright joelguittet and mender-mcu-client contributors
  * Copyright Northern.tech AS
@@ -18,53 +18,53 @@
  * limitations under the License.
  */
 
-#include "mender-scheduler.h"
+#include "mender-os.h"
 #include "mender-utils.h"
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_init(void) {
+mender_os_scheduler_init(void) {
     /* Nothing to do */
     return MENDER_OK;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_work_create(MENDER_ARG_UNUSED mender_scheduler_work_params_t *work_params, MENDER_ARG_UNUSED mender_work_t **work) {
+mender_os_scheduler_work_create(MENDER_ARG_UNUSED mender_os_scheduler_work_params_t *work_params, MENDER_ARG_UNUSED mender_work_t **work) {
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_work_activate(MENDER_ARG_UNUSED mender_work_t *work) {
+mender_os_scheduler_work_activate(MENDER_ARG_UNUSED mender_work_t *work) {
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_work_set_period(MENDER_ARG_UNUSED mender_work_t *work, MENDER_ARG_UNUSED uint32_t period) {
+mender_os_scheduler_work_set_period(MENDER_ARG_UNUSED mender_work_t *work, MENDER_ARG_UNUSED uint32_t period) {
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_work_execute(MENDER_ARG_UNUSED mender_work_t *work) {
+mender_os_scheduler_work_execute(MENDER_ARG_UNUSED mender_work_t *work) {
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_work_deactivate(MENDER_ARG_UNUSED mender_work_t *work) {
+mender_os_scheduler_work_deactivate(MENDER_ARG_UNUSED mender_work_t *work) {
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_work_delete(MENDER_ARG_UNUSED mender_work_t *work) {
+mender_os_scheduler_work_delete(MENDER_ARG_UNUSED mender_work_t *work) {
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_mutex_create(void **handle) {
+mender_os_mutex_create(void **handle) {
 
     (void)handle;
 
@@ -73,7 +73,7 @@ mender_scheduler_mutex_create(void **handle) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_mutex_take(void *handle, int32_t delay_ms) {
+mender_os_mutex_take(void *handle, int32_t delay_ms) {
 
     (void)handle;
     (void)delay_ms;
@@ -83,7 +83,7 @@ mender_scheduler_mutex_take(void *handle, int32_t delay_ms) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_mutex_give(void *handle) {
+mender_os_mutex_give(void *handle) {
 
     (void)handle;
 
@@ -92,7 +92,7 @@ mender_scheduler_mutex_give(void *handle) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_mutex_delete(void *handle) {
+mender_os_mutex_delete(void *handle) {
 
     (void)handle;
 
@@ -101,13 +101,13 @@ mender_scheduler_mutex_delete(void *handle) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_exit(void) {
+mender_os_scheduler_exit(void) {
 
     /* Nothing to do */
     return MENDER_OK;
 }
 
 __attribute__((weak)) void
-mender_scheduler_reboot(void) {
+mender_os_reboot(void) {
     return;
 }

--- a/platform/os/zephyr/src/mender-os.c
+++ b/platform/os/zephyr/src/mender-os.c
@@ -1,6 +1,6 @@
 /**
- * @file      mender-scheduler.c
- * @brief     Mender scheduler interface for Zephyr platform
+ * @file      mender-os.c
+ * @brief     Mender OS interface for Zephyr platform
  *
  * Copyright joelguittet and mender-mcu-client contributors
  * Copyright Northern.tech AS
@@ -22,10 +22,10 @@
 #include <zephyr/sys/reboot.h> /* sys_reboot() */
 #include "mender-alloc.h"
 #include "mender-log.h"
-#include "mender-scheduler.h"
+#include "mender-os.h"
 #include "mender-utils.h"
 
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
 /**
  * @brief Default work queue stack size (kB)
  */
@@ -50,22 +50,22 @@ K_THREAD_STACK_DEFINE(work_queue_stack, CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK
  */
 static struct k_work_q            work_queue;
 static struct k_work_queue_config work_queue_config;
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
 
 /**
  * @brief Work context
  */
 typedef struct mender_platform_work_t {
-    mender_scheduler_work_params_t params;    /**< Work parameters */
-    struct k_work_delayable        delayable; /**< The delayable work item executing the work function */
-    bool                           activated; /**< Flag indicating the work is activated */
+    mender_os_scheduler_work_params_t params;    /**< Work parameters */
+    struct k_work_delayable           delayable; /**< The delayable work item executing the work function */
+    bool                              activated; /**< Flag indicating the work is activated */
 } mender_platform_work_t;
 
-static void mender_scheduler_work_handler(struct k_work *work_item);
+static void mender_os_scheduler_work_handler(struct k_work *work_item);
 
 mender_err_t
-mender_scheduler_init(void) {
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+mender_os_scheduler_init(void) {
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
     /* Create and start work queue */
     work_queue_config.name      = "mender_work_queue";
     work_queue_config.no_yield  = false;
@@ -75,13 +75,13 @@ mender_scheduler_init(void) {
     k_work_queue_start(
         &work_queue, work_queue_stack, CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE * 1024, CONFIG_MENDER_SCHEDULER_WORK_QUEUE_PRIORITY, &work_queue_config);
     k_thread_name_set(k_work_queue_thread_get(&work_queue), "mender_work_queue");
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
 
     return MENDER_OK;
 }
 
 mender_err_t
-mender_scheduler_work_create(mender_scheduler_work_params_t *work_params, mender_work_t **work) {
+mender_os_scheduler_work_create(mender_os_scheduler_work_params_t *work_params, mender_work_t **work) {
     assert(NULL != work_params);
     assert(NULL != work_params->function);
     assert(NULL != work_params->name);
@@ -102,7 +102,7 @@ mender_scheduler_work_create(mender_scheduler_work_params_t *work_params, mender
         goto FAIL;
     }
 
-    k_work_init_delayable(&(work_context->delayable), mender_scheduler_work_handler);
+    k_work_init_delayable(&(work_context->delayable), mender_os_scheduler_work_handler);
 
     /* Return handle to the new work context */
     *work = work_context;
@@ -121,17 +121,17 @@ FAIL:
 }
 
 mender_err_t
-mender_scheduler_work_activate(mender_work_t *work) {
+mender_os_scheduler_work_activate(mender_work_t *work) {
     assert(NULL != work);
     assert(0 != work->params.period);
 
     mender_log_debug("Activating %s every %ju seconds", work->params.name, (uintmax_t)work->params.period);
 
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
     k_work_reschedule_for_queue(&work_queue, &(work->delayable), K_NO_WAIT);
 #else
     k_work_reschedule(&(work->delayable), K_SECONDS(1));
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
 
     /* Indicate the work has been activated */
     work->activated = true;
@@ -140,30 +140,30 @@ mender_scheduler_work_activate(mender_work_t *work) {
 }
 
 mender_err_t
-mender_scheduler_work_execute(mender_work_t *work) {
+mender_os_scheduler_work_execute(mender_work_t *work) {
     assert(NULL != work);
 
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
     k_work_reschedule_for_queue(&work_queue, &(work->delayable), K_NO_WAIT);
 #else
     k_work_reschedule(&(work->delayable), K_NO_WAIT);
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
 
     return MENDER_OK;
 }
 
 mender_err_t
-mender_scheduler_work_set_period(mender_work_t *work, uint32_t period) {
+mender_os_scheduler_work_set_period(mender_work_t *work, uint32_t period) {
     assert(NULL != work);
 
     /* Set timer period */
     work->params.period = period;
     if (work->params.period > 0) {
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
         k_work_reschedule_for_queue(&work_queue, &(work->delayable), K_SECONDS(period));
 #else
         k_work_reschedule(&(work->delayable), K_SECONDS(period));
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
     } else {
         k_work_cancel_delayable(&(work->delayable));
         work->activated = false;
@@ -173,7 +173,7 @@ mender_scheduler_work_set_period(mender_work_t *work, uint32_t period) {
 }
 
 mender_err_t
-mender_scheduler_work_deactivate(mender_work_t *work) {
+mender_os_scheduler_work_deactivate(mender_work_t *work) {
     assert(NULL != work);
 
     /* Check if the work was activated */
@@ -188,7 +188,7 @@ mender_scheduler_work_deactivate(mender_work_t *work) {
 }
 
 mender_err_t
-mender_scheduler_work_delete(mender_work_t *work) {
+mender_os_scheduler_work_delete(mender_work_t *work) {
     if (NULL == work) {
         return MENDER_OK;
     }
@@ -200,15 +200,15 @@ mender_scheduler_work_delete(mender_work_t *work) {
 }
 
 mender_err_t
-mender_scheduler_exit(void) {
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+mender_os_scheduler_exit(void) {
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
     k_work_queue_drain(&work_queue, true);
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
     return MENDER_OK;
 }
 
 static void
-mender_scheduler_work_handler(struct k_work *work_item) {
+mender_os_scheduler_work_handler(struct k_work *work_item) {
     assert(NULL != work_item);
     mender_err_t ret;
 
@@ -233,15 +233,15 @@ mender_scheduler_work_handler(struct k_work *work_item) {
     }
 
     /* Reschedule self for the next period */
-#ifdef CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE
+#ifdef CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE
     k_work_reschedule_for_queue(&work_queue, delayable_item, K_SECONDS(work->params.period));
 #else
     k_work_reschedule(delayable_item, K_SECONDS(work->params.period));
-#endif /* CONFIG_MENDER_SCHEDULER_SEPARATE_WORK_QUEUE */
+#endif /* CONFIG_MENDER_OS_SEPARATE_WORK_QUEUE */
 }
 
 mender_err_t
-mender_scheduler_mutex_create(void **handle) {
+mender_os_mutex_create(void **handle) {
     assert(NULL != handle);
 
     /* Create mutex */
@@ -257,7 +257,7 @@ mender_scheduler_mutex_create(void **handle) {
 }
 
 mender_err_t
-mender_scheduler_mutex_take(void *handle, int32_t delay_ms) {
+mender_os_mutex_take(void *handle, int32_t delay_ms) {
     assert(NULL != handle);
 
     /* Take mutex */
@@ -269,7 +269,7 @@ mender_scheduler_mutex_take(void *handle, int32_t delay_ms) {
 }
 
 mender_err_t
-mender_scheduler_mutex_give(void *handle) {
+mender_os_mutex_give(void *handle) {
     assert(NULL != handle);
 
     /* Give mutex */
@@ -281,7 +281,7 @@ mender_scheduler_mutex_give(void *handle) {
 }
 
 mender_err_t
-mender_scheduler_mutex_delete(void *handle) {
+mender_os_mutex_delete(void *handle) {
 
     /* Release memory */
     mender_free(handle);
@@ -290,6 +290,6 @@ mender_scheduler_mutex_delete(void *handle) {
 }
 
 void
-mender_scheduler_reboot(void) {
+mender_os_reboot(void) {
     sys_reboot(SYS_REBOOT_WARM);
 }


### PR DESCRIPTION
Things like `mender_scheduler_mutex_create()` and
`mender_scheduler_reboot()` look/sound quite confusing even though, strictly speaking, both mutual exclusion and reboot are related to scheduling.

Ticket: none
Changelog: none