### PR TITLE
Fix: Fail deployment in case of checksum mismatch

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -1048,6 +1048,9 @@ mender_client_update_work_function(void) {
                         goto END;
                     }
                 }
+                if (MENDER_OK != ret) {
+                    mender_client_publish_deployment_status(deployment_id, MENDER_DEPLOYMENT_STATUS_FAILURE);
+                }
                 NEXT_STATE;
                 /* fallthrough */
 

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -1033,6 +1033,8 @@ mender_client_update_work_function(void) {
                                 mender_log_error("Unable to prepare new provides");
                             }
 #endif /* CONFIG_MENDER_PROVIDES_DEPENDS */
+                        } else {
+                            mender_log_error("Artifact check failed");
                         }
 #endif /* CONFIG_MENDER_FULL_PARSE_ARTIFACT */
                     } else {


### PR DESCRIPTION
The first commit is from #143, only the last two commits are relevant for this PR.