### PR TITLE
ci: use `CI_COMMIT_SHA` as default value for `MENDER_MCU_REVISION`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,9 +11,12 @@ stages:
 
 variables:
   # mender-artifact version for tests
-  MENDER_ARTIFACT_VERSION: 4.0.0
-  MENDER_MCU_REVISION: ${CI_COMMIT_BRANCH}
-  MENDER_MCU_INTEGRATION_REVISION: main
+  MENDER_ARTIFACT_VERSION:
+    description: "mender-artifact version for tests"
+    value: 4.0.0
+  MENDER_MCU_INTEGRATION_REVISION:
+    description: "Revision of mender-mcu-integration to trigger."
+    value: main
 
 default:
   tags:
@@ -136,16 +139,12 @@ test:static:release:
 
 trigger:mender-mcu-integration:
   stage: trigger
-  rules:
-  - if: $CI_COMMIT_BRANCH =~ /^pr_[0-9]+$/
-    variables:
-      MENDER_MCU_REVISION: ${CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA}
-  - when: always
   trigger:
     project: Northern.tech/Mender/mender-mcu-integration
     branch: ${MENDER_MCU_INTEGRATION_REVISION}
     strategy: depend
   variables:
+    MENDER_MCU_REVISION: $CI_COMMIT_SHA
     PARENT_MENDER_MCU_PIPELINE_ID: $CI_PIPELINE_ID
     PARENT_MENDER_MCU_COMMIT_BRANCH: $CI_COMMIT_BRANCH
 


### PR DESCRIPTION
If we manually trigger a pipeline on a PR branch,
`CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA` will be empty, resulting in the downstream pipeline to fail.

Furthermore, specifying which revision of mender-mcu to use, is done by selecting which branch to run the pipeline for. Since we need the sha to be able to checkout PR branches in mender-mcu-integration, we can simply always set `MENDER_MCU_REVISION` to the sha of the latest commit.

Add a description to the variables you can modify to make it easier when manually creating pipelines.