### PR TITLE
chore: move `MENDER_FUNC_WEAK` to public API

### DIFF
--- a/include/mender/utils.h
+++ b/include/mender/utils.h
@@ -52,6 +52,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief A utility macro to make marking weak functions less noisy/disruptive
+ */
+#define MENDER_FUNC_WEAK __attribute__((weak))
+
+/**
  * @brief Mender error codes
  */
 typedef enum {

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -60,11 +60,6 @@ extern "C" {
 #define StringEqualN(str1, str2, n) (0 == strncmp(str1, str2, n))
 
 /**
- * @brief A utility macro to make marking weak functions less noisy/disruptive
- */
-#define MENDER_FUNC_WEAK __attribute__((weak))
-
-/**
  * @brief Linked-list
  */
 typedef struct mender_key_value_list_t {


### PR DESCRIPTION
We want to mark the callbacks in mender-mcu-integration main as weak to allow redefinition in the integration tests, see: https://github.com/mendersoftware/mender-mcu-integration/commit/6f6fb37bec396d8aaa71173796b68c9a0c70b17e