### PR TITLE
MEN-8075: Do early integrity checks for the non-payload items

### DIFF
--- a/src/core/artifact.c
+++ b/src/core/artifact.c
@@ -972,7 +972,7 @@ artifact_read_type_info(mender_artifact_ctx_t *ctx) {
         ret = MENDER_FAIL;
         goto END;
     }
-#ifdef CONFIG_MENDER_FULL_PARSE_ARTIFACT
+
     cJSON *json_provides = cJSON_GetObjectItemCaseSensitive(object, "artifact_provides");
     if (cJSON_IsObject(json_provides)) {
         if (MENDER_FAIL == artifact_parse_provides_depends(json_provides, &(ctx->payloads.values[index].provides))) {
@@ -1021,7 +1021,6 @@ artifact_read_type_info(mender_artifact_ctx_t *ctx) {
             }
         }
     }
-#endif
 
     /* Shift data in the buffer */
     /* header.tar has a checksum entry in the manifest as a whole */

--- a/src/core/artifact.c
+++ b/src/core/artifact.c
@@ -520,6 +520,10 @@ mender_artifact_release_ctx(mender_artifact_ctx_t *ctx) {
         }
         ctx->artifact_info.checksums = NULL;
 #endif
+        if (artifact_ctx == ctx) {
+            artifact_ctx = NULL;
+        }
+
         mender_free(ctx);
     }
 }

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -839,9 +839,9 @@ mender_check_artifact_requirements(mender_artifact_ctx_t *mender_artifact_ctx, m
     }
 #endif /* CONFIG_MENDER_PROVIDES_DEPENDS */
 
-    /* Check artifact integrity by comparing computed checksums with those
-     * listed in the artifacts manifest */
-    if (MENDER_OK != mender_artifact_check_integrity(mender_artifact_ctx)) {
+    /* Check payload integrity by comparing computed checksum(s) with those
+     * listed in the artifact manifest */
+    if (MENDER_OK != mender_artifact_check_integrity_remaining(mender_artifact_ctx)) {
         return MENDER_FAIL;
     }
 

--- a/src/include/artifact.h
+++ b/src/include/artifact.h
@@ -63,7 +63,6 @@ typedef struct mender_artifact_checksum_t mender_artifact_checksum_t;
 struct mender_artifact_checksum_t {
     char                       *filename;
     unsigned char               manifest[MENDER_DIGEST_BUFFER_SIZE];
-    bool                        checked;
     mender_sha256_context_t     context;
     mender_artifact_checksum_t *next;
 };
@@ -132,13 +131,13 @@ mender_err_t mender_artifact_get_ctx(mender_artifact_ctx_t **ctx);
 mender_err_t mender_artifact_process_data(mender_artifact_ctx_t *ctx, void *input_data, size_t input_length, mender_artifact_download_data_t *dl_data);
 
 /**
- * @brief Do integrity check to one specific item by comparing the manifest checksum to the computed one.
+ * @brief Do integrity check to one item by comparing the manifest checksum to the computed one and remove it from the list.
  * @param ctx Artifact context
  * @param filename Unique key for the integrity item to check
  * @return MENDER_OK if integrity is enforced, error code otherwise
  * @note Call this for early validation after the processing the data of an item in the artifact stream
  */
-mender_err_t mender_artifact_check_integrity_item(mender_artifact_ctx_t *ctx, const char *filename);
+mender_err_t mender_artifact_check_integrity_and_remove_item(mender_artifact_ctx_t *ctx, const char *filename);
 
 /**
  * @brief Do integrity checks to the remaining items by comparing the manifest checksums to the computed ones.

--- a/src/include/artifact.h
+++ b/src/include/artifact.h
@@ -63,6 +63,7 @@ typedef struct mender_artifact_checksum_t mender_artifact_checksum_t;
 struct mender_artifact_checksum_t {
     char                       *filename;
     unsigned char               manifest[MENDER_DIGEST_BUFFER_SIZE];
+    bool                        checked;
     mender_sha256_context_t     context;
     mender_artifact_checksum_t *next;
 };
@@ -131,12 +132,21 @@ mender_err_t mender_artifact_get_ctx(mender_artifact_ctx_t **ctx);
 mender_err_t mender_artifact_process_data(mender_artifact_ctx_t *ctx, void *input_data, size_t input_length, mender_artifact_download_data_t *dl_data);
 
 /**
- * @brief Do integrity checks by comparing the manifest checksums to the computed ones
+ * @brief Do integrity check to one specific item by comparing the manifest checksum to the computed one.
+ * @param ctx Artifact context
+ * @param filename Unique key for the integrity item to check
+ * @return MENDER_OK if integrity is enforced, error code otherwise
+ * @note Call this for early validation after the processing the data of an item in the artifact stream
+ */
+mender_err_t mender_artifact_check_integrity_item(mender_artifact_ctx_t *ctx, const char *filename);
+
+/**
+ * @brief Do integrity checks to the remaining items by comparing the manifest checksums to the computed ones.
  * @param ctx Artifact context
  * @return MENDER_OK if integrity is enforced, error code otherwise
- * @note Call the after the processing of data from artifact stream is complete
+ * @note Call this after the processing of the data from the artifact stream is complete
  */
-mender_err_t mender_artifact_check_integrity(mender_artifact_ctx_t *ctx);
+mender_err_t mender_artifact_check_integrity_remaining(mender_artifact_ctx_t *ctx);
 
 /**
  * @brief Function used to release artifact context

--- a/tests/unit/core/artifact_test.cpp
+++ b/tests/unit/core/artifact_test.cpp
@@ -59,6 +59,16 @@ protected:
     fs::path        artifact_path;
     fs::path        script_file_name;
 
+    void ExecuteScript(string script, fs::path tmp_dir) {
+        script_file_name = tmp_dir / "test-script.sh";
+        ofstream os(script_file_name.c_str());
+        os << script;
+        os.close();
+
+        chmod(script_file_name.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
+        ASSERT_EQ(0, system(script_file_name.c_str()));
+    }
+
     vector<uint8_t> CreateArtifact(string custom_script = "") {
         string script;
         if (custom_script.empty()) {
@@ -74,15 +84,7 @@ protected:
         }
 
         fs::path tmp_dir = fs::temp_directory_path();
-        script_file_name = tmp_dir / "test-script.sh";
-
-        ofstream os(script_file_name.c_str());
-
-        os << script;
-        os.close();
-
-        chmod(script_file_name.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
-        system(script_file_name.c_str());
+        ExecuteScript(script, tmp_dir);
 
         artifact_path = tmp_dir / "unit-test-artifact.mender";
         ifstream file(artifact_path);

--- a/tests/unit/core/artifact_test.cpp
+++ b/tests/unit/core/artifact_test.cpp
@@ -267,7 +267,7 @@ TEST_F(MenderArtifactTest, CheckIntegrityItem) {
     EXPECT_EQ(MENDER_OK, mender_artifact_process_data(ctx, data, artifact_data.size(), mock_download_data));
 
     /* Non-existing should fail */
-    EXPECT_EQ(MENDER_FAIL, mender_artifact_check_integrity_item(ctx, "nonexisting"));
+    EXPECT_EQ(MENDER_FAIL, mender_artifact_check_integrity_and_remove_item(ctx, "nonexisting"));
 
     mender_artifact_release_ctx(ctx);
 }


### PR DESCRIPTION
We shall check `version` and `header.tar` as soon as they are fully downloaded, so that the rest of the download can be aborted if the integrity of any of these is compromised.

Implemented by splitting the integrity checks into individual items (to be used during header parsing) and the remaining ones (to be used after the payload(s) have been downloaded).