### PR TITLE
chore: make max state data counter configurable

### DIFF
--- a/src/core/deployment-data.c
+++ b/src/core/deployment-data.c
@@ -31,14 +31,14 @@
 
 /**
  * @brief Deployment data version number.
- * @note cJSON stores numbers as double, so we might as well define this
- *       constant as a double to avoid type casting.
- *       This number is based on the maximum state transition count
+ * @note The default is based on the maximum state transition count
  *       from the Mender C++ client. It's a number that won't loop
  *       too many times and still give some wiggle room.
  *       If this number is exceeded, the update will be aborted.
  */
-#define MAX_STATE_DATA_STORE_COUNT 28.0
+#ifndef CONFIG_MENDER_MAX_STATE_DATA_STORE_COUNT
+#define CONFIG_MENDER_MAX_STATE_DATA_STORE_COUNT 28
+#endif /* CONFIG_MENDER_MAX_STATE_DATA_STORE_COUNT */
 
 static cJSON_bool
 json_is_string_or_null(const cJSON *json) {
@@ -115,7 +115,7 @@ mender_set_deployment_data(mender_deployment_data_t *deployment_data) {
     /* Check if max state data store count is reached */
     cJSON *item = cJSON_GetObjectItemCaseSensitive(deployment_data, MENDER_DEPLOYMENT_DATA_KEY_STATE_DATA_STORE_COUNT);
     assert(NULL != item); /* Validation above should have catched this already */
-    if (MAX_STATE_DATA_STORE_COUNT <= cJSON_GetNumberValue(item)) {
+    if ((double)CONFIG_MENDER_MAX_STATE_DATA_STORE_COUNT <= cJSON_GetNumberValue(item)) {
         /* Reset state data store count */
         cJSON_SetNumberValue(item, 0.0);
         mender_log_error("Reached max state data store count");

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -387,6 +387,14 @@ if MENDER_MCU_CLIENT
 
         menu "Error detection and recovery"
 
+           config MENDER_MAX_STATE_DATA_STORE_COUNT
+                int "Maximum number of state transitions before detecting a state loop during a deployment"
+                range 1 255
+                default 28
+                help
+                    If this limit is reached, a state loop is detected, and the deployment will be marked
+                    as a failure.
+
             config MENDER_DETECT_NETWORK_ERRORS
                 bool "Try to detect network errors and reset network to fix them"
                 default y


### PR DESCRIPTION
I mainly want this in order to exit earlier when doing the state transition tests, but I think it makes sense to let it be configurable anyways.