### PR TITLE
chore: don't set default server host to `...`

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -981,6 +981,7 @@ mender_client_update_work_function(void) {
         }                                                                      \
     } else {                                                                   \
         update_state = update_state_transitions[update_state].failure;         \
+        mender_log_debug("Entering state %s", update_state_str[update_state]); \
         if (NULL != mender_update_module) {                                    \
             if (MENDER_LOOP_DETECTED == set_and_store_state(update_state)) {   \
                 update_state = MENDER_UPDATE_STATE_FAILURE;                    \
@@ -991,9 +992,11 @@ mender_client_update_work_function(void) {
     }
 
     while (MENDER_UPDATE_STATE_END != update_state) {
-        mender_log_debug("Entering state %s", update_state_str[update_state]);
         switch (update_state) {
             case MENDER_UPDATE_STATE_DOWNLOAD:
+                /* This is usually logged in the NEXT_STATE macro, but since nothing
+                 * transitions to this state, we log it here */
+                mender_log_debug("Entering state %s", update_state_str[update_state]);
 
                 /* Check for deployment */
                 if (MENDER_OK != (ret = mender_client_check_deployment(&deployment))) {
@@ -1069,6 +1072,7 @@ mender_client_update_work_function(void) {
                 if ((MENDER_OK == ret) && !mender_update_module->requires_reboot) {
                     /* skip reboot */
                     update_state = MENDER_UPDATE_STATE_COMMIT;
+                    mender_log_debug("Entering state %s", update_state_str[update_state]);
                     set_and_store_state(update_state);
                     continue;
                 }

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -55,7 +55,6 @@ if MENDER_MCU_CLIENT
                     Set the Mender server host URL to be used on the device.
             config MENDER_SERVER_HOST
                 string "Mender server URL" if MENDER_SERVER_HOST_ON_PREM
-                default "..."
                 help
                     Specify a Mender server URL.
         endchoice


### PR DESCRIPTION
I forgot to remove the `default "..."` in the previous PR, resulting in the server host being set to `...` by default