### PR TITLE
fix: Cache `"unknown"` as artifact name

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -405,7 +405,6 @@ END:
     mender_utils_key_value_list_free(provides);
 #endif /* CONFIG_MENDER_FULL_PARSE_ARTIFACT */
 #endif /* CONFIG_MENDER_PROVIDES_DEPENDS */
-    mender_free((void *)artifact_name);
     cJSON_Delete(json_payload);
     mender_free(payload);
     return ret;

--- a/src/platform/storage/zephyr/nvs/storage.c
+++ b/src/platform/storage/zephyr/nvs/storage.c
@@ -388,11 +388,14 @@ mender_storage_get_artifact_name(const char **artifact_name) {
                 mender_log_error("Unable to allocate memory");
                 return MENDER_FAIL;
             }
+            cached_artifact_name = (char *)*artifact_name;
             return MENDER_OK;
 
         } else {
             mender_log_error("Unable to read artifact_name");
         }
+    } else {
+        cached_artifact_name = (char *)*artifact_name;
     }
 
     return ret;


### PR DESCRIPTION
In case the artifact name is not known (e.g. the initial state of a device until the first successful deployment), the string `"unknown"` is returned. We need to cache this value to fix two issues:

1. Make it cached and avoid trying to read it and fail again and again and
2. avoid memory leaks when the callers of the `mender_storage_get_artifact_name()` function get a `const` pointer and don't `free()` it

Ticket: MEN-8056
Changelog: none