### PR TITLE
chore: select `MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH` for the zephyr imag…

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ To use the `zephyr-image` Update Module, you need a board that supports
 MCUboot. The following link will filter the officially supported boards that also support MCUboot:
 * [Zephyr Project supported boards with MCU boot](https://docs.zephyrproject.org/latest/gsearch.html?q=MCUboot&check_keywords=yes&area=default#gsc.tab=0&gsc.q=MCUboot&gsc.ref=more%3Aboards&gsc.sort=)
 
+The Update Module requires a swap algorithm in order to allow rollbacks to revert to the previous image.
+The [MCUboot documentation](https://docs.mcuboot.com/readme-zephyr.html) recommends against using the
+`swap-using-scratch algorithm`, which also requires its own `scratch_partition`. We therefore require
+`MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH` to be enabled in order to use the Update Module.
+
 #### Update Modules State Machine
 
 As stated above, an Update Module for Mender MCU is set of customizable C functions. Concretely,

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -133,14 +133,20 @@ if MENDER_MCU_CLIENT
         config MENDER_ZEPHYR_IMAGE_UPDATE_MODULE
             bool "The default Mender zephyr-image update module"
             default y
+            # The MCUboot options here do not
+            # affect the MCUboot configuration
             select BOOTLOADER_MCUBOOT
+            select MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH
             select IMG_ENABLE_IMAGE_CHECK
             select IMG_ERASE_PROGRESSIVELY
             select IMG_MANAGER
             select MENDER_COMMIT_REQUIRE_AUTH
             help
                 The default zephyr-image update module handles full Zephyr images on MCUboot-based devices.
-
+                The MCUboot options selected here do not actually modify the behaviour of the bootloader
+                since it's built separately from the Mender MCU client. `BOOTLOADER_MCUBOOT`
+                and `MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH` (or another swap algorithm) must be enabled in
+                the bootloader configuration, e.g. `sysbuild.conf` if you're using sysbuild.
     endmenu
 
     menu "Platform configuration (ADVANCED)"


### PR DESCRIPTION
…e UM

We require a swap algorithm in order to revert a deployment in case of a rollback.

Note: this is deprecated in Zephyr 4.1 and replaced with `MCUBOOT_MODE_SWAP_USING_MOVE` See https://docs.zephyrproject.org/latest/releases/migration-guide-4.1.html#build-system

Ticket: MEN-8220