### PR TITLE
MEN-8203: Remove duplicated `Host` HTTP header on HTTP requests

### DIFF
--- a/src/platform/net/zephyr/http.c
+++ b/src/platform/net/zephyr/http.c
@@ -146,11 +146,6 @@ mender_http_perform(char                *jwt,
     request.recv_buf_len = mender_http_recv_buf_length;
 
     /* Add headers */
-    host_header = header_alloc_and_add(header_fields, header_fields_size, "Host: %s\r\n", host);
-    if (NULL == host_header) {
-        mender_log_error("Unable to add 'Host' header");
-        goto END;
-    }
 
     if (MENDER_FAIL == header_add(header_fields, header_fields_size, MENDER_HEADER_HTTP_USER_AGENT)) {
         mender_log_error("Unable to add 'User-Agent' header");


### PR DESCRIPTION
Zephyr OS HTTP client code already adds its own `Host:` HTTP header on the requests, which results in our HTTP requests having a duplicated header.

See:
* https://github.com/zephyrproject-rtos/zephyr/blob/v4.0.0/subsys/net/lib/http/http_client.c#L595

While some servers accept this (for example hosted Mender API Gateway) others error with 400 Bad request. In other words it is an invalid behaviour tolerated in some servers, so better to just clean it up.