### PR TITLE
MEN-8102: Generate the Mender Artifact as part of the Zephyr build byproducts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ the configuration menu.
 
 The following option **must** be set in any configuration:
 * `MENDER_SERVER_TENANT_TOKEN` which is a token that identifies which tenant a device belongs to.
+* `MENDER_ARTIFACT_NAME` which is used to generate the Mender Artifact out of the built binary
+  * Alternatively, disable auto-generation of the Mender Artifact with `MENDER_ARTIFACT_GENERATE`
 
 The most common options to modify are:
 * `MENDER_SERVER_HOST`
@@ -298,7 +300,7 @@ See the [building section](https://github.com/mendersoftware/mender-mcu-integrat
 in mender-mcu-integration for a list of the boards that we have tested, and for examples
 on how to build for them.
 
-### Creating a Mender Artifact
+### Manually creating a Mender Artifact
 
 NOTE: Compression of artifacts is **not** supported, which is why we use `--compression none`
 

--- a/src/platform/storage/posix/storage.c
+++ b/src/platform/storage/posix/storage.c
@@ -262,7 +262,13 @@ mender_storage_get_artifact_name(const char **artifact_name) {
     mender_err_t ret = mender_storage_read_file(MENDER_STORAGE_NVS_ARTICACT_NAME, (void **)artifact_name, &artifact_name_length);
     if (MENDER_OK != ret) {
         if (MENDER_NOT_FOUND == ret) {
-            *artifact_name = "unknown";
+
+            /* Get the Artifact Name from the build, if set */
+            if (strlen(CONFIG_MENDER_ARTIFACT_NAME) > 0) {
+                *artifact_name = CONFIG_MENDER_ARTIFACT_NAME;
+            } else {
+                *artifact_name = "unknown";
+            }
             return MENDER_OK;
         } else {
             mender_log_error("Unable to read artifact_name");

--- a/src/platform/storage/zephyr/nvs/storage.c
+++ b/src/platform/storage/zephyr/nvs/storage.c
@@ -384,10 +384,23 @@ mender_storage_get_artifact_name(const char **artifact_name) {
     mender_err_t ret = nvs_read_alloc(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_ARTICACT_NAME, (void **)artifact_name, &artifact_name_length);
     if (MENDER_OK != ret) {
         if (MENDER_NOT_FOUND == ret) {
-            if (NULL == (*artifact_name = mender_utils_strdup("unknown"))) {
+            const char *artifact_name_literal;
+
+            /* Get the Artifact Name from the build, if set */
+#ifdef CONFIG_MENDER_ARTIFACT_NAME
+            if (strlen(CONFIG_MENDER_ARTIFACT_NAME) > 0) {
+                artifact_name_literal = CONFIG_MENDER_ARTIFACT_NAME;
+            } else {
+                artifact_name_literal = "unknown";
+            }
+#else
+            artifact_name_literal = "unknown";
+#endif
+            if (NULL == (*artifact_name = mender_utils_strdup(artifact_name_literal))) {
                 mender_log_error("Unable to allocate memory");
                 return MENDER_FAIL;
             }
+
             cached_artifact_name = (char *)*artifact_name;
             return MENDER_OK;
 

--- a/target/posix/CMakeLists.txt
+++ b/target/posix/CMakeLists.txt
@@ -43,6 +43,7 @@ if($CACHE{COVERAGE})
 endif()
 
 # POSIX definitions, mimicking what KConfig defines for Zephyr OS builds
+target_compile_definitions(mender-mcu-client PRIVATE CONFIG_MENDER_ARTIFACT_NAME=\"${CONFIG_MENDER_ARTIFACT_NAME}\")
 if (CONFIG_MENDER_SERVER_HOST)
     target_compile_definitions(mender-mcu-client PRIVATE CONFIG_MENDER_SERVER_HOST=\"${CONFIG_MENDER_SERVER_HOST}\")
 endif()

--- a/target/zephyr/CMakeLists.txt
+++ b/target/zephyr/CMakeLists.txt
@@ -29,4 +29,9 @@ if(CONFIG_MENDER_MCU_CLIENT)
     zephyr_library_compile_definitions(-DMENDER_CLIENT_VERSION=\"${MENDER_CLIENT_VERSION}\")
     zephyr_library_compile_definitions(-D_POSIX_C_SOURCE=200809L)  # Required for strdup and strtok_r support
     zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+
+    if(CONFIG_MENDER_ARTIFACT_GENERATE)
+        include(${CMAKE_CURRENT_LIST_DIR}/mender-artifact.cmake)
+    endif()
+
 endif()

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -149,6 +149,78 @@ if MENDER_MCU_CLIENT
                 the bootloader configuration, e.g. `sysbuild.conf` if you're using sysbuild.
     endmenu
 
+    menuconfig MENDER_ARTIFACT_GENERATE
+        bool "Mender Artifact generation"
+        default y
+            help
+                Auto-generates a Mender Artifact from the Zephyr kernel image. It requires the mender-artifact CLI tool
+                installed in the workstation.
+
+        if MENDER_ARTIFACT_GENERATE
+
+            config MENDER_ARTIFACT_NAME
+                string "Name of the artifact"
+                help
+                    Name of the artifact. Mandatory.
+
+            config MENDER_ARTIFACT_TYPE
+                string "Type of payload"
+                default "zephyr-image" if MENDER_ZEPHYR_IMAGE_UPDATE_MODULE
+                help
+                    This is the same as the name of the update module. Mandatory.
+
+            config MENDER_DEVICE_TYPES_COMPATIBLE
+                string "Type of device(s) supported by the Artifact"
+                default MENDER_DEVICE_TYPE
+                help
+                    It can specify more than one device types separated by spaces. Mandatory.
+
+            config MENDER_ARTIFACT_PROVIDES
+                string "Generic KEY:VALUE which is added to the type-info -> artifact_provides section."
+                default ""
+                help
+                    It can specify more than one provides separated by spaces.
+
+            config MENDER_ARTIFACT_DEPENDS
+                string "Generic KEY:VALUE which is added to the type-info -> artifact_depends section.."
+                default ""
+                help
+                    It can specify more than one depends separated by spaces.
+
+            config MENDER_ARTIFACT_SOFTWARE_FILESYSTEM
+                string "Base identifier for the device software"
+                default "firmware"
+                help
+                    See also MENDER_ARTIFACT_SOFTWARE_NAME. The default Artifact provides will be composed
+                    as MENDER_ARTIFACT_SOFTWARE_FILESYSTEM.MENDER_ARTIFACT_SOFTWARE_NAME.version=...
+
+            config MENDER_ARTIFACT_SOFTWARE_NAME
+                string "Update type identifier for the device software"
+                default MENDER_ARTIFACT_TYPE
+                help
+                    See also MENDER_ARTIFACT_SOFTWARE_FILESYSTEM. The default Artifact provides will be composed
+                    as MENDER_ARTIFACT_SOFTWARE_FILESYSTEM.MENDER_ARTIFACT_SOFTWARE_NAME.version=...
+
+            config MENDER_ARTIFACT_EXTRA_ARGS
+                string "Extra arguments for the Mender Artifact"
+                default ""
+                help
+                    Passed verbatim to the mender-artifact CLI
+
+            config MENDER_ARTIFACT_PAYLOAD_FILE
+                string "User defined payload file for the Mender Artifact"
+                default ""
+                help
+                    When not defined, the payload is the MCUBoot signed binary at ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.bin
+
+            config MENDER_ARTIFACT_OUTPUT_FILE
+                string "User defined output Mender Artifact file"
+                default ""
+                help
+                    When not defined, the ouput file is ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.mender
+
+        endif
+
     menu "Platform configuration (ADVANCED)"
 
         choice MENDER_PLATFORM_INVENTORY_TYPE

--- a/target/zephyr/mender-artifact.cmake
+++ b/target/zephyr/mender-artifact.cmake
@@ -21,6 +21,11 @@ if(NOT mender_artifact_found)
     message(FATAL_ERROR "mender-artifact not found in PATH. Visit https://docs.mender.io/downloads#mender-artifact to download the tool or disable Artifact generation with MENDER_ARTIFACT_GENERATE")
 endif()
 
+# Print a warning on empty Artifact name
+if(CONFIG_MENDER_ARTIFACT_NAME STREQUAL "")
+    message(WARNING "MENDER_ARTIFACT_NAME cannot be empty; Artifact generation will fail. Set the variable in your build or alternatively disable the feature with CONFIG_MENDER_ARTIFACT_GENERATE=n")
+endif()
+
 # Assemble the mender-artifact arguments
 set(mender_artifact_cmd mender-artifact write module-image)
 # No compression

--- a/target/zephyr/mender-artifact.cmake
+++ b/target/zephyr/mender-artifact.cmake
@@ -1,0 +1,119 @@
+# @file      mender-artifact.cmake
+# @brief     CMake code to generate the Mender Artifact
+#
+# Copyright Northern.tech AS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check for the tool and the Artifact Name. The rest of the parameters have defaults
+find_program(mender_artifact_found mender-artifact)
+if(NOT mender_artifact_found)
+    message(FATAL_ERROR "mender-artifact not found in PATH. Visit https://docs.mender.io/downloads#mender-artifact to download the tool or disable Artifact generation with MENDER_ARTIFACT_GENERATE")
+endif()
+
+# Assemble the mender-artifact arguments
+set(mender_artifact_cmd mender-artifact write module-image)
+# No compression
+set(mender_artifact_cmd ${mender_artifact_cmd} --compression none)
+# Artifact name
+set(mender_artifact_cmd ${mender_artifact_cmd} --artifact-name '${CONFIG_MENDER_ARTIFACT_NAME}')
+# Update Module
+set(mender_artifact_cmd ${mender_artifact_cmd} --type ${CONFIG_MENDER_ARTIFACT_TYPE})
+# Device type
+string(REPLACE " " ";" device_type_list ${CONFIG_MENDER_DEVICE_TYPES_COMPATIBLE})
+foreach(device_type ${device_type_list})
+    set(mender_artifact_cmd ${mender_artifact_cmd} --device-type ${device_type})
+endforeach()
+# Artifact provides
+if(NOT CONFIG_MENDER_ARTIFACT_PROVIDES STREQUAL "")
+    string(REPLACE " " ";" provides_list ${CONFIG_MENDER_ARTIFACT_PROVIDES})
+    foreach(provides ${provides_list})
+        set(mender_artifact_cmd ${mender_artifact_cmd} --provides ${provides})
+    endforeach()
+endif()
+# Artifact depends
+if(NOT CONFIG_MENDER_ARTIFACT_DEPENDS STREQUAL "")
+    string(REPLACE " " ";" depends_list ${CONFIG_MENDER_ARTIFACT_DEPENDS})
+    foreach(depends ${depends_list})
+        set(mender_artifact_cmd ${mender_artifact_cmd} --depends ${depends})
+    endforeach()
+endif()
+# Prefix for the default provides
+set(mender_artifact_cmd ${mender_artifact_cmd} --software-filesystem ${CONFIG_MENDER_ARTIFACT_SOFTWARE_FILESYSTEM})
+set(mender_artifact_cmd ${mender_artifact_cmd} --software-name ${CONFIG_MENDER_ARTIFACT_SOFTWARE_NAME})
+# Extra arguments
+if(NOT CONFIG_MENDER_ARTIFACT_EXTRA_ARGS STREQUAL "")
+    separate_arguments(extra_args UNIX_COMMAND ${CONFIG_MENDER_ARTIFACT_EXTRA_ARGS})
+    set(mender_artifact_cmd ${mender_artifact_cmd} ${extra_args})
+endif()
+# Input file
+if(CONFIG_MENDER_ARTIFACT_PAYLOAD_FILE STREQUAL "")
+    set(mender_artifact_payload ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.bin)
+else()
+    set(mender_artifact_payload ${CONFIG_MENDER_ARTIFACT_PAYLOAD_FILE})
+endif()
+set(mender_artifact_cmd ${mender_artifact_cmd} --file ${mender_artifact_payload})
+# Output file
+if(CONFIG_MENDER_ARTIFACT_OUTPUT_FILE STREQUAL "")
+    set(mender_artifact_output ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.mender)
+else()
+    set(mender_artifact_output ${CONFIG_MENDER_ARTIFACT_OUTPUT_FILE})
+endif()
+set(mender_artifact_cmd ${mender_artifact_cmd} --output-path ${mender_artifact_output})
+
+
+#### Design note ###
+#
+# Ideally, we would have used the existing hook from Zephyr project to trigger the
+# Mender Artifact build as a "Build Event"
+# (https://cmake.org/cmake/help/latest/command/add_custom_command.html#build-events)
+# through extra_post_build_commands with something like:
+#
+# set_property(
+#     GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND ${mender_artifact_cmd}
+# )
+# set_property(
+#     GLOBAL APPEND PROPERTY extra_post_build_byproducts ${mender_artifact_output}
+# )
+#
+# However, the Mender Artifact post build command would depend on the signed
+# kernel, which is in itself generated through a post build command
+# (https://github.com/zephyrproject-rtos/zephyr/blob/v4.0.0/cmake/mcuboot.cmake#L149)
+# and there is no way to "sort" the command or declare interdependencies between
+# them.
+#
+# So here is the workaround: as a post build command just remove the Artifact,
+# so that we clear any stale Artifact every time that we build a new kernel. And
+# then as custom target that runs always, we check and generate the Artifact
+# opportunistically.
+# 
+##################
+
+set_property(
+    GLOBAL APPEND PROPERTY
+    extra_post_build_commands
+    COMMAND
+    rm -f ${mender_artifact_output}
+)
+
+add_custom_target(
+    mender-artifact ALL
+    COMMAND
+    test -f ${mender_artifact_output} ||
+    echo "Generating Mender Artifact ${CONFIG_MENDER_ARTIFACT_NAME} for devices ${CONFIG_MENDER_DEVICE_TYPES_COMPATIBLE} from ${mender_artifact_payload}" &&
+    ${mender_artifact_cmd} 
+    DEPENDS
+    ${mender_artifact_payload}
+    BYPRODUCTS
+    ${mender_artifact_output}
+)


### PR DESCRIPTION
Integrate with CMake build system so that a Mender Artifact is generated next to the Zephyr kernel and its byproducts.

For the most simple use case, only the Artifact Name needs to be specified, the  rest are optional or have sane default values. This policy imitates the design of other Mender build integrations, like Yocto or mender-convert.

TODO:
- [x] Update README(s)
- [x] Discuss the new requirement `CONFIG_MENDER_ARTIFACT_NAME`
- [x] Add a warning on empty Artifact name
- [x] Use build time Artifact name instead of `unknown` when not found in the store