### PR TITLE
feat: added dormant certificate

### DIFF
--- a/cmake/CMake_posix_defaults.txt
+++ b/cmake/CMake_posix_defaults.txt
@@ -21,6 +21,7 @@ set(CONFIG_MENDER_PLATFORM_SCHEDULER_TYPE "posix" CACHE STRING "Scheduler type")
 set(CONFIG_MENDER_PLATFORM_STORAGE_TYPE "posix" CACHE STRING "Storage type")
 set(CONFIG_MENDER_PLATFORM_TLS_TYPE "generic/mbedtls" CACHE STRING "TLS type")
 set(CONFIG_MENDER_PLATFORM_SHA_TYPE "generic/mbedtls" CACHE STRING "SHA type")
+set(CONFIG_MENDER_PLATFORM_CERT_TYPE "posix" CACHE STRING "Certificate type")
 
 include(${CMAKE_CURRENT_LIST_DIR}/CMake_defaults.txt)
 

--- a/cmake/CMake_weak_defaults.txt
+++ b/cmake/CMake_weak_defaults.txt
@@ -21,6 +21,7 @@ set(CONFIG_MENDER_PLATFORM_SCHEDULER_TYPE "generic/weak" CACHE STRING "Scheduler
 set(CONFIG_MENDER_PLATFORM_STORAGE_TYPE "generic/weak" CACHE STRING "Storage type")
 set(CONFIG_MENDER_PLATFORM_TLS_TYPE "generic/weak" CACHE STRING "TLS type")
 set(CONFIG_MENDER_PLATFORM_SHA_TYPE "generic/weak" CACHE STRING "SHA type")
+set(CONFIG_MENDER_PLATFORM_CERT_TYPE "generic/weak" CACHE STRING "Certificate type")
 
 include(${CMAKE_CURRENT_LIST_DIR}/CMake_defaults.txt)
 

--- a/cmake/mender_mcu_sources.txt
+++ b/cmake/mender_mcu_sources.txt
@@ -137,6 +137,12 @@ if (NOT CONFIG_MENDER_PLATFORM_SHA_TYPE)
 else()
     message(STATUS "Using custom '${CONFIG_MENDER_PLATFORM_SHA_TYPE}' platform SHA implementation")
 endif()
+if (NOT CONFIG_MENDER_PLATFORM_CERT_TYPE)
+    message(STATUS "Using default 'generic/weak' platform certificate implementation")
+    set(CONFIG_MENDER_PLATFORM_CERT_TYPE "generic/weak")
+else()
+    message(STATUS "Using custom '${CONFIG_MENDER_PLATFORM_CERT_TYPE}' platform certificate implementation")
+endif()
 
 # Set MENDER_MCU_SOURCES
 file(GLOB MENDER_MCU_SOURCES
@@ -172,6 +178,11 @@ if (CONFIG_MENDER_PLATFORM_NET_TYPE STREQUAL "zephyr")
     list(APPEND MENDER_MCU_SOURCES
         "${MENDER_MCU_ROOT}/src/platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/net.c"
     )
+endif()
+if (CONFIG_MENDER_SERVER_DORMANT_CERTIFICATE)
+    list(APPEND MENDER_MCU_SOURCES
+            "${MENDER_MCU_ROOT}/src/platform/certs/${CONFIG_MENDER_PLATFORM_CERT_TYPE}/certs.c"
+        )
 endif()
 
 # Set MENDER_MCU_INCLUDE

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -32,6 +32,10 @@
 #include "deployment-data.h"
 #include "error-counters.h"
 
+#ifdef CONFIG_MENDER_SERVER_DORMANT_CERTIFICATE
+#include "certs.h"
+#endif /* CONFIG_MENDER_SERVER_DORMANT_CERTIFICATE */
+
 #ifndef CONFIG_MENDER_CLIENT_INVENTORY_DISABLE
 #include "inventory.h"
 #endif /* CONFIG_MENDER_CLIENT_INVENTORY_DISABLE */
@@ -352,6 +356,14 @@ mender_client_init(mender_client_config_t *config, mender_client_callbacks_t *ca
         mender_log_error("Unable to initialize API");
         goto END;
     }
+
+#ifdef CONFIG_MENDER_SERVER_DORMANT_CERTIFICATE
+    if (MENDER_OK != (ret = mender_add_dormant_cert())) {
+        /* error logged in function */
+        goto END;
+    }
+    mender_log_debug("Added dormant certificate");
+#endif
 
 #ifndef CONFIG_MENDER_CLIENT_INVENTORY_DISABLE
     if (MENDER_OK

--- a/src/include/certs.h
+++ b/src/include/certs.h
@@ -1,0 +1,39 @@
+/**
+ * @file      certs.h
+ * @brief     Mender MCU Certificate (private API)
+ *
+ * Copyright Northern.tech AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MENDER_CERTS_PRIV_H__
+#define __MENDER_CERTS_PRIV_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "utils.h"
+
+/**
+ * @brief Add dormant certificate for potential disaster recovery scenarios
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_add_dormant_cert(void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __MENDER_CERTS_PRIV_H__ */

--- a/src/platform/certs/generic/weak/certs.c
+++ b/src/platform/certs/generic/weak/certs.c
@@ -1,0 +1,27 @@
+/**
+ * @file      certs.c
+ * @brief     Mender MCU Certificate for weak platform
+ *
+ * Copyright Northern.tech AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "certs.h"
+#include "utils.h"
+
+MENDER_FUNC_WEAK mender_err_t
+mender_add_dormant_cert(void) {
+    /* Nothing to do */
+    return MENDER_NOT_IMPLEMENTED;
+}

--- a/src/platform/certs/posix/certs.c
+++ b/src/platform/certs/posix/certs.c
@@ -1,0 +1,26 @@
+/**
+ * @file      certs.c
+ * @brief     Mender MCU Certificate for posix
+ *
+ * Copyright Northern.tech AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "certs.h"
+
+mender_err_t
+mender_add_dormant_cert(void) {
+    /* Nothing to do */
+    return MENDER_OK;
+}

--- a/src/platform/certs/zephyr/certs.c
+++ b/src/platform/certs/zephyr/certs.c
@@ -1,0 +1,42 @@
+/**
+ * @file      certs.c
+ * @brief     Mender MCU Certificate for zephyr
+ *
+ * Copyright Northern.tech AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h> /* size_t */
+#include <zephyr/net/tls_credentials.h>
+
+#include "certs.h"
+#include "log.h"
+#include <errno.h>
+
+static const unsigned char dormant_certificate[] = {
+#include "dormant.cer.inc"
+};
+
+/* @note See https://docs.zephyrproject.org/4.0.0/doxygen/html/group__tls__credentials.html#ga640ff6dd3eb4d5017feaab6fab2bb2f7 */
+mender_err_t
+mender_add_dormant_cert(void) {
+    int ret;
+    if (0
+        != (ret = tls_credential_add(
+                CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_DORMANT, TLS_CREDENTIAL_CA_CERTIFICATE, dormant_certificate, sizeof(dormant_certificate)))) {
+        mender_log_error("Failed to add dormant certificate. (result = %d, error: %s)", ret, strerror(errno));
+        return MENDER_FAIL;
+    }
+    return MENDER_OK;
+}

--- a/target/zephyr/CMakeLists.txt
+++ b/target/zephyr/CMakeLists.txt
@@ -43,3 +43,17 @@ if(CONFIG_MENDER_MCU_CLIENT)
     endif()
 
 endif()
+
+# Install the dormant certificate
+if (CONFIG_MENDER_SERVER_DORMANT_CERTIFICATE)
+    set(DORMANT_CERTIFICATE_LINK "https://letsencrypt.org/certs/isrg-root-x2.der")
+    set(DORMANT_CERTIFICATE_SHA256 69729b8e15a86efc177a57afb7171dfc64add28c2fca8cf1507e34453ccb1470)
+    set(DORMANT_CERTIFICATE "${CMAKE_CURRENT_BINARY_DIR}/dormant.cer")
+    file(DOWNLOAD ${DORMANT_CERTIFICATE_LINK} ${DORMANT_CERTIFICATE} EXPECTED_HASH SHA256=${DORMANT_CERTIFICATE_SHA256})
+
+    generate_inc_file_for_target(app
+        ${DORMANT_CERTIFICATE}
+        "${ZEPHYR_BINARY_DIR}/include/generated/dormant.cer.inc"
+    )
+
+endif()

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -68,6 +68,16 @@ if MENDER_MCU_CLIENT
                 default "https://eu.hosted.mender.io"
         endif
 
+        config MENDER_SERVER_DORMANT_CERTIFICATE
+            bool "Enable dormant certificate for potential server recovery"
+            default y
+            help
+                Enable this option to install a dormant Let's Encrypt certficiate on the device
+                for potential server recovery scenarios. This certficiate can be used to generate
+                a new certificate in case the root certificate for the Mender server is revoked.
+                It is strongly recommended to keep this option enabled to ensure server communication
+                resilience in critical situations.
+
         config MENDER_SERVER_TENANT_TOKEN
             string "Mender server Tenant Token"
             help
@@ -371,6 +381,23 @@ if MENDER_MCU_CLIENT
             default "generic/mbedtls" if MENDER_PLATFORM_SHA_TYPE_MBEDTLS
             default "generic/weak" if MENDER_PLATFORM_SHA_TYPE_WEAK
 
+        choice MENDER_PLATFORM_CERT_TYPE
+            prompt "Mender platform certificate implementation rype"
+            default MENDER_PLATFORM_CERT_TYPE_DEFAULT
+            help
+                Specify platform certificate implementation type, select 'weak' to use you own implementation.
+
+            config MENDER_PLATFORM_CERT_TYPE_DEFAULT
+                bool "zephyr"
+            config MENDER_PLATFORM_CERT_TYPE_WEAK
+                bool "weak"
+        endchoice
+
+        config MENDER_PLATFORM_CERT_TYPE
+            string
+            default "zephyr" if MENDER_PLATFORM_CERT_TYPE_DEFAULT
+            default "generic/weak" if MENDER_PLATFORM_CERT_TYPE_WEAK
+
     endmenu
 
     if MENDER_PLATFORM_MEM_TYPE_DEFAULT
@@ -420,6 +447,14 @@ if MENDER_MCU_CLIENT
                 default 2
                 help
                     A secondary security tag that ROOT CA server credential will be referenced with, typically used to authenticate the server from where to download Mender Artifacts. See tls_credential_add.
+
+            config MENDER_NET_CA_CERTIFICATE_TAG_DORMANT
+                int "Dormant CA certificate tag for Server rescue"
+                # the tag is arbirtrarily set to 9
+                default 9
+                depends on MENDER_SERVER_DORMANT_CERTIFICATE
+                help
+                    A security tag that the dormant certificate will be referenced with, typically used for backup in disaster recovery scenarios. See tls_credential_add.
 
             config MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED
                 bool "Enable MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY"


### PR DESCRIPTION
Suggestion for how to add the dormant/backup certificate. I didn't think it made sense to add it to `mender-mcu-integration`. Either way, we'll create a follow-up ticket for actually testing the X2 certificate, as it turned out to be non-trivial to create a server with that specific root ca