### PR TITLE
MEN-8223: Avoid committing aborted deployment

### DIFF
--- a/include/mender/utils.h
+++ b/include/mender/utils.h
@@ -77,12 +77,11 @@ typedef enum {
  * @brief Deployment status
  */
 typedef enum {
-    MENDER_DEPLOYMENT_STATUS_DOWNLOADING,      /**< Status is "downloading" */
-    MENDER_DEPLOYMENT_STATUS_INSTALLING,       /**< Status is "installing" */
-    MENDER_DEPLOYMENT_STATUS_REBOOTING,        /**< Status is "rebooting" */
-    MENDER_DEPLOYMENT_STATUS_SUCCESS,          /**< Status is "success" */
-    MENDER_DEPLOYMENT_STATUS_FAILURE,          /**< Status is "failure" */
-    MENDER_DEPLOYMENT_STATUS_ALREADY_INSTALLED /**< Status is "already installed" */
+    MENDER_DEPLOYMENT_STATUS_DOWNLOADING, /**< Status is "downloading" */
+    MENDER_DEPLOYMENT_STATUS_INSTALLING,  /**< Status is "installing" */
+    MENDER_DEPLOYMENT_STATUS_REBOOTING,   /**< Status is "rebooting" */
+    MENDER_DEPLOYMENT_STATUS_SUCCESS,     /**< Status is "success" */
+    MENDER_DEPLOYMENT_STATUS_FAILURE,     /**< Status is "failure" */
 } mender_deployment_status_t;
 
 /**

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -30,6 +30,25 @@
 #include "utils.h"
 
 /**
+ * @brief HTTP retry mechanism parameters
+ *
+ * On unreliable networks, an HTTP request can easily fail due to some short
+ * network issue. Thus there needs to be a retry mechanism to prevent every
+ * single such temporary failure to cause an error.
+ *
+ * 5 attempts (so 4 retries, to be precise) with 100ms as the first pause
+ * interval doubled with every attempt gives a total of 1500ms period of retries
+ * with nice progressive pauses in between (100, 200, 400, 800ms).
+ *
+ * @note: RETRY_ATTEMPTS is uint8_t,
+ *        INTERVAL_BASE * INTERVAL_FACTOR**(ATTEMPTS - 1) has to fit in uint16_t
+ *        Or the code below has to be adjusted, but such a long sleep doesn't make sense here!
+ */
+#define HTTP_RETRY_ATTEMPTS        5
+#define HTTP_RETRY_INTERVAL_BASE   100 /* milliseconds */
+#define HTTP_RETRY_INTERVAL_FACTOR 2
+
+/**
  * @brief Paths of the mender-server APIs
  */
 #define MENDER_API_PATH_POST_AUTHENTICATION_REQUESTS "/api/devices/v1/authentication/auth_requests"
@@ -174,6 +193,8 @@ perform_authentication(void) {
     char                    *signature        = NULL;
     size_t                   signature_length = 0;
     int                      status           = 0;
+    uint8_t                  remaining_attempts;
+    uint16_t                 retry_interval;
 
     /* Get public key in PEM format */
     if (MENDER_OK != (ret = mender_tls_get_public_key_pem(&public_key_pem))) {
@@ -222,15 +243,28 @@ perform_authentication(void) {
     }
 
     /* Perform HTTP request */
-    if (MENDER_OK
-        != (ret = mender_http_perform(NULL,
-                                      MENDER_API_PATH_POST_AUTHENTICATION_REQUESTS,
-                                      MENDER_HTTP_POST,
-                                      payload,
-                                      signature,
-                                      &mender_api_http_text_callback,
-                                      (void *)&response,
-                                      &status))) {
+    remaining_attempts = HTTP_RETRY_ATTEMPTS;
+    retry_interval     = HTTP_RETRY_INTERVAL_BASE;
+    do {
+        ret = mender_http_perform(NULL,
+                                  MENDER_API_PATH_POST_AUTHENTICATION_REQUESTS,
+                                  MENDER_HTTP_POST,
+                                  payload,
+                                  signature,
+                                  &mender_api_http_text_callback,
+                                  (void *)&response,
+                                  &status);
+        if (MENDER_RETRY_ERROR == ret) {
+            mender_os_sleep(retry_interval);
+            retry_interval = retry_interval * HTTP_RETRY_INTERVAL_FACTOR;
+            remaining_attempts--;
+
+            /* Just in case something was already gathered as response. */
+            FREE_AND_NULL(response);
+        }
+    } while ((MENDER_RETRY_ERROR == ret) && (remaining_attempts > 0));
+
+    if (MENDER_OK != ret) {
         mender_log_error("Unable to perform HTTP request");
         mender_err_count_net_inc();
         goto END;
@@ -279,6 +313,8 @@ END:
 static mender_err_t
 authenticated_http_perform(char *path, mender_http_method_t method, char *payload, char *signature, char **response, int *status) {
     mender_err_t ret;
+    uint8_t      remaining_attempts;
+    uint16_t     retry_interval;
 
     if (MENDER_IS_ERROR(ret = ensure_authenticated_and_locked())) {
         /* Errors already logged. */
@@ -291,7 +327,20 @@ authenticated_http_perform(char *path, mender_http_method_t method, char *payloa
         return ret;
     }
 
-    ret = mender_http_perform(api_jwt, path, method, payload, signature, &mender_api_http_text_callback, response, status);
+    remaining_attempts = HTTP_RETRY_ATTEMPTS;
+    retry_interval     = HTTP_RETRY_INTERVAL_BASE;
+    do {
+        ret = mender_http_perform(api_jwt, path, method, payload, signature, &mender_api_http_text_callback, response, status);
+        if (MENDER_RETRY_ERROR == ret) {
+            mender_os_sleep(retry_interval);
+            retry_interval = retry_interval * HTTP_RETRY_INTERVAL_FACTOR;
+            remaining_attempts--;
+
+            /* Just in case something was already gathered as response. */
+            FREE_AND_NULL(*response);
+        }
+    } while ((MENDER_RETRY_ERROR == ret) && (remaining_attempts > 0));
+
     if (MENDER_OK != mender_os_mutex_give(auth_lock)) {
         mender_log_error("Unable to release the authentication lock");
         return MENDER_FAIL;

--- a/src/core/api.c
+++ b/src/core/api.c
@@ -594,13 +594,11 @@ mender_api_publish_deployment_status(const char *id, mender_deployment_status_t 
     }
 
     /* Compute path */
-    size_t str_length = strlen(MENDER_API_PATH_PUT_DEPLOYMENT_STATUS) - strlen("%s") + strlen(id) + 1;
-    if (NULL == (path = (char *)mender_malloc(str_length))) {
+    if (mender_utils_asprintf(&path, MENDER_API_PATH_PUT_DEPLOYMENT_STATUS, id) <= 0) {
         mender_log_error("Unable to allocate memory");
         ret = MENDER_FAIL;
         goto END;
     }
-    snprintf(path, str_length, MENDER_API_PATH_PUT_DEPLOYMENT_STATUS, id);
 
     /* Perform HTTP request */
     if (MENDER_OK != (ret = authenticated_http_perform(path, MENDER_HTTP_PUT, payload, NULL, &response, &status))) {

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -1243,6 +1243,18 @@ mender_client_update_work_function(void) {
                 if (MENDER_IS_ERROR(ret = mender_api_ensure_authenticated())) {
                     mender_log_error("Failed to authenticate before commit, rejecting the update");
                 }
+
+                /* Try to update the deployment status one last time before
+                   commit so that we have a chance to detect an aborted
+                   deployment before it's too late. */
+                if (!MENDER_IS_ERROR(ret)
+                    && (MENDER_OK != (ret = mender_client_publish_deployment_status(deployment_id, MENDER_DEPLOYMENT_STATUS_INSTALLING)))) {
+                    if (MENDER_ABORTED == ret) {
+                        mender_log_info("Aborted deployment, not committing");
+                    } else {
+                        mender_log_error("Failed to check deployment status before commit, rejecting the update");
+                    }
+                }
 #endif /* CONFIG_MENDER_COMMIT_REQUIRE_AUTH */
                 if (!MENDER_IS_ERROR(ret) && (MENDER_OK != (ret = mender_commit_artifact_data()))) {
                     mender_log_error("Unable to commit artifact data");

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -229,8 +229,6 @@ mender_utils_deployment_status_to_string(mender_deployment_status_t deployment_s
         return "success";
     } else if (MENDER_DEPLOYMENT_STATUS_FAILURE == deployment_status) {
         return "failure";
-    } else if (MENDER_DEPLOYMENT_STATUS_ALREADY_INSTALLED == deployment_status) {
-        return "already-installed";
     }
 
     return NULL;

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -141,6 +141,12 @@ mender_err_t mender_os_mutex_delete(void *handle);
  */
 void mender_os_reboot(void);
 
+/**
+ * @brief Sleep for a given period
+ * @retry period A period to sleep for (in milliseconds)
+ */
+void mender_os_sleep(uint32_t period_ms);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/platform/os/generic/weak/os.c
+++ b/src/platform/os/generic/weak/os.c
@@ -111,3 +111,8 @@ MENDER_FUNC_WEAK void
 mender_os_reboot(void) {
     return;
 }
+
+MENDER_FUNC_WEAK void
+mender_os_sleep(MENDER_ARG_UNUSED uint32_t period_ms) {
+    return;
+}

--- a/src/platform/os/posix/os.c
+++ b/src/platform/os/posix/os.c
@@ -428,3 +428,8 @@ void
 mender_os_reboot(void) {
     reboot(RB_AUTOBOOT);
 }
+
+void
+mender_os_sleep(uint32_t period_ms) {
+    usleep((useconds_t)period_ms * 1000);
+}

--- a/src/platform/os/zephyr/os.c
+++ b/src/platform/os/zephyr/os.c
@@ -314,3 +314,8 @@ void
 mender_os_reboot(void) {
     sys_reboot(SYS_REBOOT_WARM);
 }
+
+void
+mender_os_sleep(uint32_t period_ms) {
+    k_sleep(K_MSEC(period_ms));
+}

--- a/tests/unit/core/utils_test.cpp
+++ b/tests/unit/core/utils_test.cpp
@@ -161,10 +161,10 @@ TEST(MenderUtilsTest, DeploymentStatusToString) {
         mender_deployment_status_t deployment_status;
         string                     status_string;
     } DeploymentStatusString;
-    DeploymentStatusString status[]
-        = { { MENDER_DEPLOYMENT_STATUS_DOWNLOADING, "downloading" }, { MENDER_DEPLOYMENT_STATUS_INSTALLING, "installing" },
-            { MENDER_DEPLOYMENT_STATUS_REBOOTING, "rebooting" },     { MENDER_DEPLOYMENT_STATUS_SUCCESS, "success" },
-            { MENDER_DEPLOYMENT_STATUS_FAILURE, "failure" },         { MENDER_DEPLOYMENT_STATUS_ALREADY_INSTALLED, "already-installed" } };
+    DeploymentStatusString status[] = { { MENDER_DEPLOYMENT_STATUS_DOWNLOADING, "downloading" },
+                                        { MENDER_DEPLOYMENT_STATUS_INSTALLING, "installing" },
+                                        { MENDER_DEPLOYMENT_STATUS_REBOOTING, "rebooting" },
+                                        { MENDER_DEPLOYMENT_STATUS_SUCCESS, "success" } };
 
     string status_string;
     for (size_t i = 0; i < sizeof(status) / sizeof(status[0]); i++) {


### PR DESCRIPTION
TODO:
- [x] check for aborted deployment before committing
- [x] implement a retry in `publish_deployment_status()`  so that a network hiccup doesn't cause deployment failure

~Based on #188.~