### PR TITLE
ci: switch from public to GCP runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,8 +37,7 @@ default:
     - apt-get update && apt-get install -y git clang-format pcregrep
   tags:
     # QA-866: Ubuntu 24.04 image cannot properly run on our private runners.
-    # Temporarely setting it to GitLab Hosted runners
-    - saas-linux-medium-amd64
+    - mender-qa-worker-generic-light
 
 test:static:license:
   extends: .test:static
@@ -57,6 +56,9 @@ test:smoke-build:posix:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:12-slim
   needs: []
+  tags:
+    # QA-866: Ubuntu 24.04 image cannot properly run on our private runners.
+    - mender-qa-worker-generic-light
   before_script:
     - apt-get update && apt-get install -yqq
       cmake git make pkg-config python3
@@ -70,6 +72,9 @@ test:smoke-build:weak:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:12-slim
   needs: []
+  tags:
+    # QA-866: Ubuntu 24.04 image cannot properly run on our private runners.
+    - mender-qa-worker-generic-light
   before_script:
     - apt-get update && apt-get install -yqq
       cmake git make pkg-config python3
@@ -82,6 +87,9 @@ test:smoke-build:weak:
 test:unit:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:12-slim
+  tags:
+    # QA-866: Ubuntu 24.04 image cannot properly run on our private runners.
+    - mender-qa-worker-generic-light
   before_script:
     - apt update && apt install -yyq
       cmake git make pkg-config python3
@@ -120,8 +128,7 @@ test:unit:
     - make --jobs=$(nproc --all) --keep-going check
   tags:
     # QA-866: Ubuntu 24.04 image cannot properly run on our private runners.
-    # Temporarily setting it to GitLab Hosted runners
-    - saas-linux-medium-amd64
+    - mender-qa-worker-generic-light 
 
 test:static:asan:
   extends: .test:static:template


### PR DESCRIPTION
To make build safer within our own runner

Ticket: QA-866