### PR TITLE
MEN-8351: fix(build): Set default value for secondary CA cert to false + misc

### DIFF
--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -452,7 +452,7 @@ if MENDER_MCU_CLIENT
 
             config MENDER_NET_CA_CERTIFICATE_TAG_DORMANT
                 int "Dormant CA certificate tag for Server rescue"
-                # the tag is arbirtrarily set to 9
+                # the tag is arbitrarily set to 9
                 default 9
                 depends on MENDER_SERVER_DORMANT_CERTIFICATE
                 help

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -43,10 +43,12 @@ if MENDER_MCU_CLIENT
 
             config MENDER_SERVER_HOST_US
                 bool "https://hosted.mender.io"
+                select MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED
                 help
                     hosted Mender US
             config MENDER_SERVER_HOST_EU
                 bool "https://eu.hosted.mender.io"
+                select MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED
                 help
                     hosted Mender EU
             config MENDER_SERVER_HOST_ON_PREM
@@ -460,7 +462,7 @@ if MENDER_MCU_CLIENT
 
             config MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED
                 bool "Enable MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY"
-                default y
+                default n
                 help
                     Enables the secondary CA tag. If this option is enabled, the user must add the two certificates with tls_credential_add
 

--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -469,7 +469,7 @@ if MENDER_MCU_CLIENT
                 range 0 2
                 default 2
                 help
-                    Peer verification level for TLS connection.
+                    Peer verification level for TLS connection - see mbedtls/ssl.h, in particular mbedtls_ssl_conf_authmode(), for details. 2 (default) requires SSL peer verification, 1 makes verification optional (not implemented) and 0 skips verification.
 
         endmenu
 


### PR DESCRIPTION
The secondary CA cert is really optional, as a custom Mender Server could use the same domain for both API calls and Artifacts storage.

Set `MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY_ENABLED` default to `n` and instead select it when selecting hosted Mender option(s).