### PR TITLE
fix: Add explicit 413 handling when publishing deployment logs

### DIFF
--- a/src/core/api.c
+++ b/src/core/api.c
@@ -872,7 +872,12 @@ mender_api_publish_deployment_logs(const char *id) {
         /* Deployment aborted */
         mender_api_print_response_error(response, status);
         ret = MENDER_ABORTED;
+    } else if (413 == status) {
+        /* Request body too large, retrying won't help */
+        mender_api_print_response_error(response, status);
+        ret = MENDER_FAIL;
     } else {
+        /* TODO: This should return MENDER_RETRY_ERROR and be retried accordingly. See MEN-9543 */
         mender_api_print_response_error(response, status);
         ret = MENDER_FAIL;
     }


### PR DESCRIPTION
Return a regular failure when encountering 413 Content too large errors when publishing deployment logs. This is done to ensure we don't retry unnecessarily.

Ticket: MEN-9389