### PR TITLE
ci: use the .json5 suffix for renovate config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ variables:
   RENOVATE_REQUIRE_CONFIG: "optional"
   RENOVATE_ONBOARDING: "false"
   RENOVATE_GIT_PRIVATE_KEY: $SSH_PRIVATE_KEY
-  RENOVATE_CONFIG_FILE: "$CI_PROJECT_DIR/renovate.json"
+  RENOVATE_CONFIG_FILE: "$CI_PROJECT_DIR/renovate.json5"
   FORCE_RENOVATE_RUN:
     description: "Force a renovate bot run"
     value: "false"


### PR DESCRIPTION
The config was changed from .json to .json5
Follow-up from https://github.com/mendersoftware/mender-mcu/pull/234