### PR TITLE
fix: correctly deref deployment_data double pointer for null check

### DIFF
--- a/src/core/deployment-data.c
+++ b/src/core/deployment-data.c
@@ -159,7 +159,7 @@ mender_get_deployment_data(mender_deployment_data_t **deployment_data) {
     /* Parse deployment data from JSON string. */
     *deployment_data = cJSON_Parse(json_str);
     mender_free(json_str);
-    if (NULL == deployment_data) {
+    if (NULL == *deployment_data) {
         mender_log_error("Unable to parse deployment data");
         return MENDER_FAIL;
     }


### PR DESCRIPTION
Null check as it stood will always succeed, as assert at top of function already checks it.

(cherry picked from commit 0bc67571782d19778edf7fe0d8158f29b8dbcf11)