### PR TITLE
chore(deps): bump mbedtls to 3.6.6

### DIFF
--- a/target/posix/CMakeLists.txt
+++ b/target/posix/CMakeLists.txt
@@ -108,7 +108,7 @@ include(FetchContent)
 FetchContent_Declare(
   MbedTLS
   GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls
-  GIT_TAG        v3.6.2
+  GIT_TAG        v3.6.6
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   FIND_PACKAGE_ARGS NAMES MbedTLS
 )


### PR DESCRIPTION
GCC 15 and newer has the new flag "Wunterminated-string-initialization" enabled by default which causes compilation errors.

Bump MbedTLS to 3.6.6 to allow compiling on systems with GCC >= 15.