### PR TITLE
feat: make logging definitions generic

### DIFF
--- a/include/mender/log.h
+++ b/include/mender/log.h
@@ -46,6 +46,36 @@ extern "C" {
 #define CONFIG_MENDER_LOG_LEVEL MENDER_LOG_LEVEL_INF
 #endif /* CONFIG_MENDER_LOG_LEVEL */
 
+typedef struct {
+    /**
+     * @brief Initialize mender log
+     * @return MENDER_OK if the function succeeds, error code otherwise
+     */
+    mender_err_t (*init)(void);
+
+    /**
+    * @brief Release mender log
+    * @return MENDER_OK if the function succeeds, error code otherwise
+    */
+    mender_err_t (*exit)(void);
+
+    mender_err_t (*print)(uint8_t level, const char *filename, const char *function, int line, char *format, ...);
+#ifdef CONFIG_MENDER_DEPLOYMENT_LOGS
+    /**
+     * @brief Activate deployment logs saving
+     * @return MENDER_OK if the function succeeds, error code otherwise
+     */
+    mender_err_t (*deployment_logs_activate)(void);
+
+    /**
+     * @brief Deactivate deployment logs saving
+     * @return MENDER_OK if the function succeeds, error code otherwise
+     */
+    mender_err_t (*mender_deployment_logs_deactivate)(void);
+#endif /* CONFIG_MENDER_DEPLOYMENT_LOGS */
+} mender_log_t;
+extern mender_log_t mender_log;
+
 #ifdef __ZEPHYR__
 
 LOG_MODULE_DECLARE(mender, CONFIG_MENDER_LOG_LEVEL);
@@ -98,24 +128,12 @@ LOG_MODULE_DECLARE(mender, CONFIG_MENDER_LOG_LEVEL);
 #else /* __ZEPHYR__ */
 
 /**
- * @brief Print log
- * @param level Log level
- * @param filename Filename
- * @param function Function name
- * @param line Line
- * @param format Log format
- * @param ... Arguments
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_log_print(uint8_t level, const char *filename, const char *function, int line, char *format, ...);
-
-/**
  * @brief Print error log
  * @param ... Arguments
  * @return Error code
  */
 #if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_ERR
-#define mender_log_error(...) ({ mender_log_print(MENDER_LOG_LEVEL_ERR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
+#define mender_log_error(...) ({ mender_log.print(MENDER_LOG_LEVEL_ERR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
 #else
 #define mender_log_error(...)
 #endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_ERR */
@@ -126,7 +144,7 @@ mender_err_t mender_log_print(uint8_t level, const char *filename, const char *f
  * @return Error code
  */
 #if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_WRN
-#define mender_log_warning(...) ({ mender_log_print(MENDER_LOG_LEVEL_WRN, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
+#define mender_log_warning(...) ({ mender_log.print(MENDER_LOG_LEVEL_WRN, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
 #else
 #define mender_log_warning(...)
 #endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_WRN */
@@ -137,7 +155,7 @@ mender_err_t mender_log_print(uint8_t level, const char *filename, const char *f
  * @return Error code
  */
 #if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_INF
-#define mender_log_info(...) ({ mender_log_print(MENDER_LOG_LEVEL_INF, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
+#define mender_log_info(...) ({ mender_log.print(MENDER_LOG_LEVEL_INF, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
 #else
 #define mender_log_info(...)
 #endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_INF */
@@ -149,7 +167,7 @@ mender_err_t mender_log_print(uint8_t level, const char *filename, const char *f
  * @return Error code
  */
 #if CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_DBG
-#define mender_log_debug(...) ({ mender_log_print(MENDER_LOG_LEVEL_DBG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
+#define mender_log_debug(...) ({ mender_log.print(MENDER_LOG_LEVEL_DBG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); })
 #else
 #define mender_log_debug(...)
 #endif /* CONFIG_MENDER_LOG_LEVEL >= MENDER_LOG_LEVEL_DBG */

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -369,7 +369,7 @@ mender_client_init(mender_client_config_t *config, mender_client_callbacks_t *ca
         mender_log_error("Unable to initialize scheduler");
         goto END;
     }
-    if (MENDER_OK != (ret = mender_log_init())) {
+    if (MENDER_OK != (ret = mender_log.init())) {
         mender_log_error("Unable to initialize log");
         goto END;
     }
@@ -554,7 +554,7 @@ mender_client_exit(void) {
     mender_api_exit();
     mender_tls_exit();
     mender_storage_exit();
-    mender_log_exit();
+    mender_log.exit();
     mender_client_network_release();
 
     /* Release memory */

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -26,32 +26,6 @@ extern "C" {
 
 #include <mender/log.h>
 
-/**
- * @brief Initialize mender log
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_log_init(void);
-
-/**
- * @brief Release mender log
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_log_exit(void);
-
-#ifdef CONFIG_MENDER_DEPLOYMENT_LOGS
-/**
- * @brief Activate deployment logs saving
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_deployment_logs_activate(void);
-
-/**
- * @brief Deactivate deployment logs saving
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_deployment_logs_deactivate(void);
-#endif /* CONFIG_MENDER_DEPLOYMENT_LOGS */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/platform/log/generic/weak/log.c
+++ b/src/platform/log/generic/weak/log.c
@@ -20,15 +20,15 @@
 #include "log.h"
 #include "utils.h"
 
-MENDER_FUNC_WEAK mender_err_t
-mender_log_init(void) {
+static mender_err_t
+default_mender_log_init(void) {
 
     /* Nothing to do */
     return MENDER_OK;
 }
 
-MENDER_FUNC_WEAK mender_err_t
-mender_log_print(uint8_t level, const char *filename, const char *function, int line, char *format, ...) {
+static mender_err_t
+default_mender_log_print(uint8_t level, const char *filename, const char *function, int line, char *format, ...) {
 
     (void)level;
     (void)filename;
@@ -40,9 +40,33 @@ mender_log_print(uint8_t level, const char *filename, const char *function, int 
     return MENDER_OK;
 }
 
-MENDER_FUNC_WEAK mender_err_t
-mender_log_exit(void) {
+static mender_err_t
+default_mender_log_exit(void) {
 
     /* Nothing to do */
     return MENDER_OK;
 }
+
+#ifdef CONFIG_MENDER_DEPLOYMENT_LOGS
+static mender_err_t
+default_mender_deployment_logs_activate(void) {
+    /* Nothing to do */
+    return MENDER_OK;
+}
+
+static mender_err_t
+default_mender_deployment_logs_deactivate(void) {
+    /* Nothing to do */
+    return MENDER_OK;
+}
+#endif /* CONFIG_MENDER_DEPLOYMENT_LOGS */
+
+mender_log_t mender_log = {
+    .init  = default_mender_log_init,
+    .exit  = default_mender_log_exit,
+    .print = default_mender_log_print,
+#ifdef CONFIG_MENDER_DEPLOYMENT_LOGS
+    .deployment_logs_activate   = default_mender_deployment_logs_activate,
+    .deployment_logs_deactivate = default_mender_deployment_logs_deactivate,
+#endif /* CONFIG_MENDER_DEPLOYMENT_LOGS */
+};

--- a/src/platform/log/posix/log.c
+++ b/src/platform/log/posix/log.c
@@ -20,15 +20,15 @@
 #include <time.h>
 #include "log.h"
 
-mender_err_t
-mender_log_init(void) {
+static mender_err_t
+default_mender_log_init(void) {
 
     /* Nothing to do */
     return MENDER_OK;
 }
 
-mender_err_t
-mender_log_print(uint8_t level, const char *filename, const char *function, int line, char *format, ...) {
+static mender_err_t
+default_mender_log_print(uint8_t level, const char *filename, const char *function, int line, char *format, ...) {
 
     (void)function;
     struct timespec now;
@@ -64,9 +64,33 @@ mender_log_print(uint8_t level, const char *filename, const char *function, int 
     return MENDER_OK;
 }
 
-mender_err_t
-mender_log_exit(void) {
+static mender_err_t
+default_mender_log_exit(void) {
 
     /* Nothing to do */
     return MENDER_OK;
 }
+
+#ifdef CONFIG_MENDER_DEPLOYMENT_LOGS
+static mender_err_t
+default_mender_deployment_logs_activate(void) {
+    /* Default activation logic */
+    return MENDER_OK;
+}
+
+static mender_err_t
+default_mender_deployment_logs_deactivate(void) {
+    /* Default deactivation logic */
+    return MENDER_OK;
+}
+#endif /* CONFIG_MENDER_DEPLOYMENT_LOGS */
+
+mender_log_t mender_log = {
+    .init  = default_mender_log_init,
+    .exit  = default_mender_log_exit,
+    .print = default_mender_log_print,
+#ifdef CONFIG_MENDER_DEPLOYMENT_LOGS
+    .deployment_logs_activate   = default_mender_deployment_logs_activate,
+    .deployment_logs_deactivate = default_mender_deployment_logs_deactivate,
+#endif /* CONFIG_MENDER_DEPLOYMENT_LOGS */
+};


### PR DESCRIPTION
In an effort to make porting mender-mcu to other platforms such as FreeRtOS easier, it's important to make APIs generic, easy to overwrite, and with sane defaults. One such as example is logging.

Vanilla FreeRtOS has a printf method, but anyone forced to use the TI FreeRtOS has to use the DebugP_log methods.

Declare the init, exit, print, deployment_logs_activate, and mender_deployment_logs_deactivate methods in a mender_log_t struct so users can integrate their own logging solution easily while linking to mender-mcu.