### PR TITLE
fix(core): use-after-free in mender_filter_provides clears-provides loop

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -798,7 +798,13 @@ mender_filter_provides(mender_artifact_ctx_t *mender_artifact_ctx, mender_key_va
     for (size_t i = 0; i < mender_artifact_ctx->payloads.size; i++) {
         for (size_t j = 0; j < mender_artifact_ctx->payloads.values[i].clears_provides_size; j++) {
             const char *to_clear = mender_artifact_ctx->payloads.values[i].clears_provides[j];
-            for (mender_key_value_list_t *item = *stored_provides; NULL != item; item = item->next) {
+            /* Capture the next pointer before the loop body: when the key
+             * matches, mender_utils_key_value_list_delete_node() frees the
+             * current node, so advancing via item->next afterwards would
+             * dereference freed memory (use-after-free). */
+            mender_key_value_list_t *next_item = NULL;
+            for (mender_key_value_list_t *item = *stored_provides; NULL != item; item = next_item) {
+                next_item = item->next;
                 if (MENDER_OK != mender_utils_compare_wildcard(item->key, to_clear, &matches)) {
                     mender_log_error("Unable to compare wildcard %s with key %s", to_clear, item->key);
                     goto END;


### PR DESCRIPTION
## Summary

`mender_filter_provides()` (core/client.c) has a use-after-free in the "clears provides" loop. It walks the `stored_provides` list and, when an entry matches a `clears_provides` wildcard, calls `mender_utils_key_value_list_delete_node()` — which frees the current node. The loop then advances with `item = item->next`, dereferencing the just-freed node.

```c
for (mender_key_value_list_t *item = *stored_provides; NULL != item; item = item->next) {
    ...
    if (matches && MENDER_OK != mender_utils_key_value_list_delete_node(stored_provides, item->key)) { ... }
    /* item was just freed when it matched; item->next below is a use-after-free */
}
```

Depending on the allocator, `item->next` reads a dangling pointer. In the best case it happens to still work; in the worst case the list traversal never terminates.

## Impact / when it triggers

This path only runs when there are **stored provides that match a `clears_provides` pattern**, i.e. from the second update onward (a device that has already committed one artifact and is now applying another). On a first deployment `stored_provides` is empty and the bug is dormant, which makes it easy to miss.

I hit it porting mender-mcu to a bare-metal pico-sdk build on the RP2350: on the second update / rollback it caused an unbounded loop that tripped the hardware watchdog, so the deployment never progressed to a success/failure report. The bug itself is platform-agnostic.

## Fix

Capture `item->next` before the loop body, so iteration is safe against the current node being deleted.

## Notes
- Single-file, minimal change; no functional change other than not dereferencing freed memory.
- Commit is DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)