### PR TITLE
ci: configure codecov coverage thresholds

### DIFF
--- a/.check-headers-ignore
+++ b/.check-headers-ignore
@@ -1,2 +1,3 @@
 .gitlab-ci.yml
+codecov.yml
 west.yml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        informational: true


### PR DESCRIPTION
Codecov defaults let any coverage decrease pass. This sets an explicit policy: fail the project status on a drop larger than 1%, and report patch coverage at an 80% target without blocking merges on it.

Statuses stay advisory — this does not change branch protection or required checks.

**Merge order: independent.** No dependency on the container or template PRs.

Ticket: [QA-1573](https://northerntech.atlassian.net/browse/QA-1573)

[QA-1573]: https://northerntech.atlassian.net/browse/QA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ