### PR TITLE
ci: use zephyr-4.2.x branch in mender-mcu-integration trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ variables:
     description: |
       Revision of mender-mcu-integration to trigger.
       Should correspond to the gitlab branch: `pr_XXX`
-    value: main
+    value: zephyr-4.2.x
 
   # Renovate required variables
   RENOVATE_PLATFORM: github


### PR DESCRIPTION
mender-mcu 1.0.x doesn't support zephyr 4.4 which is used in mender-mcu-integration main.