### PR TITLE
fix(Zephyr): Do not enable IMG_ENABLE_IMAGE_CHECK

### DIFF
--- a/target/zephyr/Kconfig
+++ b/target/zephyr/Kconfig
@@ -209,7 +209,6 @@ if MENDER_MCU_CLIENT
             # affect the MCUboot configuration
             select BOOTLOADER_MCUBOOT
             select MCUBOOT_MODE_SWAP_USING_MOVE
-            select IMG_ENABLE_IMAGE_CHECK
             select IMG_ERASE_PROGRESSIVELY
             select IMG_MANAGER
             select MENDER_COMMIT_REQUIRE_AUTH


### PR DESCRIPTION
We don't use this built-in mechanism for checking signature of a flashed image. We may in the future (see the ticket), but currently this just adds extra code we never call/use.

Ticket: MEN-7486
Changelog: None