### PR TITLE
fix: cap the mender log level at CONFIG_LOG_MAXIMUM_LEVEL

### DIFF
--- a/src/platform/log/esp-idf/log.c
+++ b/src/platform/log/esp-idf/log.c
@@ -56,7 +56,7 @@ mender_log_print(uint8_t level, MENDER_ARG_UNUSED const char *filename, const ch
             break;
     }
 
-    ESP_LOG_LEVEL(esp_level, "mender", "%s:%d: %s", function, line, msg);
+    ESP_LOG_LEVEL_LOCAL(esp_level, "mender", "%s:%d: %s", function, line, msg);
 
     return MENDER_OK;
 }

--- a/target/esp-idf/Kconfig
+++ b/target/esp-idf/Kconfig
@@ -97,18 +97,27 @@ menu "Mender client"
 
         choice MENDER_LOG_LEVEL_CHOICE
             prompt "Mender client log level"
-            default MENDER_LOG_LEVEL_INF
+            default MENDER_LOG_LEVEL_INF if LOG_MAXIMUM_LEVEL >= 3
+            default MENDER_LOG_LEVEL_WRN if LOG_MAXIMUM_LEVEL >= 2
+            default MENDER_LOG_LEVEL_ERR if LOG_MAXIMUM_LEVEL >= 1
+            default MENDER_LOG_LEVEL_OFF
 
+            comment "Levels above LOG_MAXIMUM_LEVEL are hidden"
+                depends on LOG_MAXIMUM_LEVEL < 4
             config MENDER_LOG_LEVEL_OFF
                 bool "Off"
             config MENDER_LOG_LEVEL_ERR
                 bool "Error"
+                depends on LOG_MAXIMUM_LEVEL >= 1
             config MENDER_LOG_LEVEL_WRN
                 bool "Warning"
+                depends on LOG_MAXIMUM_LEVEL >= 2
             config MENDER_LOG_LEVEL_INF
                 bool "Info"
+                depends on LOG_MAXIMUM_LEVEL >= 3
             config MENDER_LOG_LEVEL_DBG
                 bool "Debug"
+                depends on LOG_MAXIMUM_LEVEL >= 4
         endchoice
 
         config MENDER_LOG_LEVEL


### PR DESCRIPTION
Picking a log level above `CONFIG_LOG_MAXIMUM_LEVEL` compiled in log calls that were discarded at runtime.

Ticket: None
Changelog: None