### PR TITLE
ci: drop the per repo renovate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,12 +12,8 @@ include:
     inputs:
       coverage_file: coverage.lcov
       flag: unit-tests
-  - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
-    inputs:
-      stage: "renovate"
 
 stages:
-  - renovate
   - test
   - changelog
   - release


### PR DESCRIPTION
Renovate now runs centrally from NorthernTechHQ/renovate-ring, which reads this repo's renovate.json5 straight from GitHub. Nothing about grouping or managers changes.

The job only ever triggered on a pipeline schedule and that schedule is already deleted, so this removes config that can no longer run.