### PR TITLE
feat: Integrate mender-artifact into ESP-IDF builds

### DIFF
--- a/cmake/mender-artifact.cmake
+++ b/cmake/mender-artifact.cmake
@@ -1,0 +1,80 @@
+# @file      mender-artifact.cmake
+# @brief     CMake code to generate the Mender Artifact
+#
+# Copyright Northern.tech AS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Check for the tool and the Artifact Name. The rest of the parameters have defaults
+find_program(mender_artifact_found mender-artifact)
+if(NOT mender_artifact_found)
+    message(FATAL_ERROR "mender-artifact not found in PATH. Visit https://docs.mender.io/downloads#mender-artifact to download the tool or disable Artifact generation with MENDER_ARTIFACT_GENERATE")
+endif()
+
+# Fail if version mender-artifact version doesn't have the Artifact size functionality
+if (CONFIG_MENDER_ARTIFACT_SIZE_LIMITS)
+    execute_process(COMMAND mender-artifact write module-image --help OUTPUT_VARIABLE HELP_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(FIND "${HELP_OUTPUT}" "--warn-artifact-size" FOUND_ARTIFACT_SIZE)
+    if (FOUND_ARTIFACT_SIZE LESS 0)
+        message(FATAL_ERROR "Setting Artifact size limits require mender-artifact >= 4.2.0")
+    endif()
+endif()
+
+# Print a warning on empty Artifact name
+if(CONFIG_MENDER_ARTIFACT_NAME STREQUAL "")
+    message(WARNING "MENDER_ARTIFACT_NAME cannot be empty; Artifact generation will fail. Set the variable in your build or alternatively disable the feature with CONFIG_MENDER_ARTIFACT_GENERATE=n")
+endif()
+
+# Assemble the mender-artifact arguments
+set(mender_artifact_cmd mender-artifact write module-image)
+# No compression
+set(mender_artifact_cmd ${mender_artifact_cmd} --compression none)
+# Artifact name
+set(mender_artifact_cmd ${mender_artifact_cmd} --artifact-name '${CONFIG_MENDER_ARTIFACT_NAME}')
+# Update Module
+set(mender_artifact_cmd ${mender_artifact_cmd} --type ${CONFIG_MENDER_ARTIFACT_TYPE})
+# Device type
+string(REPLACE " " ";" device_type_list ${CONFIG_MENDER_DEVICE_TYPES_COMPATIBLE})
+foreach(device_type ${device_type_list})
+    set(mender_artifact_cmd ${mender_artifact_cmd} --compatible-types ${device_type})
+endforeach()
+# Artifact provides
+if(NOT CONFIG_MENDER_ARTIFACT_PROVIDES STREQUAL "")
+    string(REPLACE " " ";" provides_list ${CONFIG_MENDER_ARTIFACT_PROVIDES})
+    foreach(provides ${provides_list})
+        set(mender_artifact_cmd ${mender_artifact_cmd} --provides ${provides})
+    endforeach()
+endif()
+# Artifact depends
+if(NOT CONFIG_MENDER_ARTIFACT_DEPENDS STREQUAL "")
+    string(REPLACE " " ";" depends_list ${CONFIG_MENDER_ARTIFACT_DEPENDS})
+    foreach(depends ${depends_list})
+        set(mender_artifact_cmd ${mender_artifact_cmd} --depends ${depends})
+    endforeach()
+endif()
+# Prefix for the default provides
+set(mender_artifact_cmd ${mender_artifact_cmd} --software-filesystem ${CONFIG_MENDER_ARTIFACT_SOFTWARE_FILESYSTEM})
+set(mender_artifact_cmd ${mender_artifact_cmd} --software-name ${CONFIG_MENDER_ARTIFACT_SOFTWARE_NAME})
+# Set fail/warn limits on Artifact size
+if (CONFIG_MENDER_ARTIFACT_WARN_SIZE)
+    set(mender_artifact_cmd ${mender_artifact_cmd} --warn-artifact-size ${CONFIG_MENDER_ARTIFACT_WARN_SIZE})
+endif()
+if (CONFIG_MENDER_ARTIFACT_MAX_SIZE)
+    set(mender_artifact_cmd ${mender_artifact_cmd} --max-artifact-size ${CONFIG_MENDER_ARTIFACT_MAX_SIZE})
+endif()
+# Extra arguments
+if(NOT CONFIG_MENDER_ARTIFACT_EXTRA_ARGS STREQUAL "")
+    separate_arguments(extra_args UNIX_COMMAND ${CONFIG_MENDER_ARTIFACT_EXTRA_ARGS})
+    set(mender_artifact_cmd ${mender_artifact_cmd} ${extra_args})
+endif()

--- a/target/esp-idf/Kconfig
+++ b/target/esp-idf/Kconfig
@@ -182,6 +182,107 @@ menu "Mender client"
                 for details).
     endmenu
 
+    menuconfig MENDER_ARTIFACT_GENERATE
+        bool "Mender Artifact generation"
+        default y
+            help
+                Auto-generates a Mender Artifact from the ESP-IDF binary image. It requires the mender-artifact CLI tool
+                installed in the workstation.
+
+        if MENDER_ARTIFACT_GENERATE
+
+            config MENDER_ARTIFACT_NAME
+                string "Name of the artifact"
+                help
+                    Name of the artifact. Mandatory.
+
+            config MENDER_ARTIFACT_TYPE
+                string "Type of payload"
+                default "esp-ota" if MENDER_ESP_OTA_UPDATE_MODULE
+                help
+                    This is the same as the name of the update module. Mandatory.
+
+            config MENDER_DEVICE_TYPES_COMPATIBLE
+                string "Type of device(s) supported by the Artifact"
+                default MENDER_DEVICE_TYPE
+                help
+                    It can specify more than one device types separated by spaces. Mandatory.
+
+            config MENDER_ARTIFACT_PROVIDES
+                string "Generic KEY:VALUE which is added to the type-info -> artifact_provides section."
+                default ""
+                help
+                    It can specify more than one provides separated by spaces.
+
+            config MENDER_ARTIFACT_DEPENDS
+                string "Generic KEY:VALUE which is added to the type-info -> artifact_depends section.."
+                default ""
+                help
+                    It can specify more than one depends separated by spaces.
+
+            config MENDER_ARTIFACT_SOFTWARE_FILESYSTEM
+                string "Base identifier for the device software"
+                default "firmware"
+                help
+                    See also MENDER_ARTIFACT_SOFTWARE_NAME. The default Artifact provides will be composed
+                    as MENDER_ARTIFACT_SOFTWARE_FILESYSTEM.MENDER_ARTIFACT_SOFTWARE_NAME.version=...
+
+            config MENDER_ARTIFACT_SOFTWARE_NAME
+                string "Update type identifier for the device software"
+                default MENDER_ARTIFACT_TYPE
+                help
+                    See also MENDER_ARTIFACT_SOFTWARE_FILESYSTEM. The default Artifact provides will be composed
+                    as MENDER_ARTIFACT_SOFTWARE_FILESYSTEM.MENDER_ARTIFACT_SOFTWARE_NAME.version=...
+
+            config MENDER_ARTIFACT_EXTRA_ARGS
+                string "Extra arguments for the Mender Artifact"
+                default ""
+                help
+                    Passed verbatim to the mender-artifact CLI
+
+            config MENDER_ARTIFACT_PAYLOAD_FILE
+                string "User defined payload file for the Mender Artifact"
+                default ""
+                help
+                    When not defined, the payload is the MCUBoot signed binary at ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.bin
+
+            config MENDER_ARTIFACT_OUTPUT_FILE
+                string "User defined output Mender Artifact file"
+                default ""
+                help
+                    When not defined, the output file is ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.mender
+
+        menuconfig MENDER_ARTIFACT_SIZE_LIMITS
+            bool "Artifact size limits"
+            default y
+                help
+                    Enable size limits for Artifacts.
+                        When enabled, you can configure limits to:
+                        - Warn when Artifact size exceeds a given limit
+                        - Fail the build and prevent artifact creation if size exceeds a maximum limit
+
+                    Requires mender-artifact >= 4.2.0
+
+            config MENDER_ARTIFACT_WARN_SIZE
+                string "Warning limit for Artifact size"
+                default "5MB" if MENDER_DEVICE_TIER_MICRO
+                default "10GB" if MENDER_DEVICE_TIER_STANDARD
+                depends on MENDER_ARTIFACT_SIZE_LIMITS
+                help
+                    Warn if size of the Artifact exceeds the given limit.
+                    Defaults to 5MB for micro tier and 10GB for standard tier.
+                    Leave empty to disable.
+                    You can specify units: "123B", "1MB", etc. Supported units: B, KB, MB, GB, TB
+
+            config MENDER_ARTIFACT_MAX_SIZE
+                string "Maximum size"
+                depends on MENDER_ARTIFACT_SIZE_LIMITS
+                help
+                    Fail build if size of the Artifact exceeds the given limit.
+                    Leave empty to disable.
+                    You can specify units: "123B", "1MB", etc. Supported units: B, KB, MB, GB, TB
+        endif
+
     menu "Scheduler options (ADVANCED)"
 
         config MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE

--- a/target/esp-idf/component.cmake
+++ b/target/esp-idf/component.cmake
@@ -130,3 +130,7 @@ endif()
 # TODO: figure out how to dynamically get the version.
 # The component manager only fetches the staged files, so no git information is available
 target_compile_definitions(${COMPONENT_LIB} PUBLIC MENDER_CLIENT_VERSION="esp-idf-demo")
+
+if(CONFIG_MENDER_ARTIFACT_GENERATE)
+  include(${CMAKE_CURRENT_LIST_DIR}/mender-artifact.cmake)
+endif()

--- a/target/esp-idf/mender-artifact.cmake
+++ b/target/esp-idf/mender-artifact.cmake
@@ -1,0 +1,52 @@
+# @file      mender-artifact.cmake
+# @brief     ESP-IDF -specific CMake code to generate Mender Artifacts
+#
+# Copyright Northern.tech AS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/mender-artifact.cmake)
+
+function(run_mender_artifact)
+  set(base_cmd ${ARGV})
+  # Input file
+  if(CONFIG_MENDER_ARTIFACT_PAYLOAD_FILE STREQUAL "")
+    set(mender_artifact_payload "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.bin")
+  else()
+    set(mender_artifact_payload ${CONFIG_MENDER_ARTIFACT_PAYLOAD_FILE})
+  endif()
+  # Output file
+  if(CONFIG_MENDER_ARTIFACT_OUTPUT_FILE STREQUAL "")
+    set(mender_artifact_output "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.mender")
+  else()
+    set(mender_artifact_output ${CONFIG_MENDER_ARTIFACT_OUTPUT_FILE})
+  endif()
+  set(MENDER_ARTIFACT_CMD_ALL ${base_cmd} --file ${mender_artifact_payload} --output-path ${mender_artifact_output})
+
+  # Execute a command right after the main app binary is successfully linked
+  add_custom_command(TARGET app POST_BUILD
+    COMMAND ${MENDER_ARTIFACT_CMD_ALL}
+    COMMENT "Generating Mender Artifact..."
+  )
+endfunction()
+
+# We need to defer the Artifact creation to the the source directory scope,
+# i.e. to the main app/project build because that's where the main binary
+# is built.
+# On top of that, ${mender_artifact_cmd} is a directory/function-local variable,
+# but cmake_language(DEFER) only re-evaluates variable references in its
+# arguments at the time the deferred call runs (in the scope of
+# CMAKE_SOURCE_DIR), not when it is scheduled. Wrapping in EVAL CODE with a
+# bracket argument forces immediate substitution so the value survives.
+cmake_language(EVAL CODE "cmake_language(DEFER DIRECTORY \"${CMAKE_SOURCE_DIR}\" CALL run_mender_artifact [[${mender_artifact_cmd}]])")
+

--- a/target/zephyr/mender-artifact.cmake
+++ b/target/zephyr/mender-artifact.cmake
@@ -1,5 +1,5 @@
 # @file      mender-artifact.cmake
-# @brief     CMake code to generate the Mender Artifact
+# @brief     Zephyr-specific CMake code to generate Mender Artifacts
 #
 # Copyright Northern.tech AS
 #
@@ -15,68 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Check for the tool and the Artifact Name. The rest of the parameters have defaults
-find_program(mender_artifact_found mender-artifact)
-if(NOT mender_artifact_found)
-    message(FATAL_ERROR "mender-artifact not found in PATH. Visit https://docs.mender.io/downloads#mender-artifact to download the tool or disable Artifact generation with MENDER_ARTIFACT_GENERATE")
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/mender-artifact.cmake)
 
-# Fail if version mender-artifact version doesn't have the Artifact size functionality
-if (CONFIG_MENDER_ARTIFACT_SIZE_LIMITS)
-    execute_process(COMMAND mender-artifact write module-image --help OUTPUT_VARIABLE HELP_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(FIND "${HELP_OUTPUT}" "--warn-artifact-size" FOUND_ARTIFACT_SIZE)
-    if (FOUND_ARTIFACT_SIZE LESS 0)
-        message(FATAL_ERROR "Setting Artifact size limits require mender-artifact >= 4.2.0")
-    endif()
-endif()
-
-# Print a warning on empty Artifact name
-if(CONFIG_MENDER_ARTIFACT_NAME STREQUAL "")
-    message(WARNING "MENDER_ARTIFACT_NAME cannot be empty; Artifact generation will fail. Set the variable in your build or alternatively disable the feature with CONFIG_MENDER_ARTIFACT_GENERATE=n")
-endif()
-
-# Assemble the mender-artifact arguments
-set(mender_artifact_cmd mender-artifact write module-image)
-# No compression
-set(mender_artifact_cmd ${mender_artifact_cmd} --compression none)
-# Artifact name
-set(mender_artifact_cmd ${mender_artifact_cmd} --artifact-name '${CONFIG_MENDER_ARTIFACT_NAME}')
-# Update Module
-set(mender_artifact_cmd ${mender_artifact_cmd} --type ${CONFIG_MENDER_ARTIFACT_TYPE})
-# Device type
-string(REPLACE " " ";" device_type_list ${CONFIG_MENDER_DEVICE_TYPES_COMPATIBLE})
-foreach(device_type ${device_type_list})
-    set(mender_artifact_cmd ${mender_artifact_cmd} --compatible-types ${device_type})
-endforeach()
-# Artifact provides
-if(NOT CONFIG_MENDER_ARTIFACT_PROVIDES STREQUAL "")
-    string(REPLACE " " ";" provides_list ${CONFIG_MENDER_ARTIFACT_PROVIDES})
-    foreach(provides ${provides_list})
-        set(mender_artifact_cmd ${mender_artifact_cmd} --provides ${provides})
-    endforeach()
-endif()
-# Artifact depends
-if(NOT CONFIG_MENDER_ARTIFACT_DEPENDS STREQUAL "")
-    string(REPLACE " " ";" depends_list ${CONFIG_MENDER_ARTIFACT_DEPENDS})
-    foreach(depends ${depends_list})
-        set(mender_artifact_cmd ${mender_artifact_cmd} --depends ${depends})
-    endforeach()
-endif()
-# Prefix for the default provides
-set(mender_artifact_cmd ${mender_artifact_cmd} --software-filesystem ${CONFIG_MENDER_ARTIFACT_SOFTWARE_FILESYSTEM})
-set(mender_artifact_cmd ${mender_artifact_cmd} --software-name ${CONFIG_MENDER_ARTIFACT_SOFTWARE_NAME})
-# Set fail/warn limits on Artifact size
-if (CONFIG_MENDER_ARTIFACT_WARN_SIZE)
-    set(mender_artifact_cmd ${mender_artifact_cmd} --warn-artifact-size ${CONFIG_MENDER_ARTIFACT_WARN_SIZE})
-endif()
-if (CONFIG_MENDER_ARTIFACT_MAX_SIZE)
-    set(mender_artifact_cmd ${mender_artifact_cmd} --max-artifact-size ${CONFIG_MENDER_ARTIFACT_MAX_SIZE})
-endif()
-# Extra arguments
-if(NOT CONFIG_MENDER_ARTIFACT_EXTRA_ARGS STREQUAL "")
-    separate_arguments(extra_args UNIX_COMMAND ${CONFIG_MENDER_ARTIFACT_EXTRA_ARGS})
-    set(mender_artifact_cmd ${mender_artifact_cmd} ${extra_args})
-endif()
 # Input file
 if(CONFIG_MENDER_ARTIFACT_PAYLOAD_FILE STREQUAL "")
     set(mender_artifact_payload ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.bin)
@@ -91,7 +31,6 @@ else()
     set(mender_artifact_output ${CONFIG_MENDER_ARTIFACT_OUTPUT_FILE})
 endif()
 set(mender_artifact_cmd ${mender_artifact_cmd} --output-path ${mender_artifact_output})
-
 
 #### Design note ###
 #


### PR DESCRIPTION
Making it easier for developers to deploy updates using Mender.

Many parts of the logic can be shared between Zephyr and ESP-IDF with a bit of refactoring.

Ticket: None
Changelog: None