### PR TITLE
fix: POSIX smoke tests

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -104,16 +104,16 @@ mender_utils_strrstr(const char *haystack, const char *needle) {
     assert(NULL != haystack);
     assert(NULL != needle);
 
-    char *r = NULL;
+    const char *r = NULL;
 
     if (!needle[0]) {
         return (char *)haystack + strlen(haystack);
     }
 
     while (1) {
-        char *p = strstr(haystack, needle);
+        const char *p = strstr(haystack, needle);
         if (!p) {
-            return r;
+            return (char *)r;
         }
         r        = p;
         haystack = p + 1;
@@ -551,7 +551,7 @@ mender_utils_compare_wildcard(const char *str, const char *wildcard_str, bool *m
     const char *to_match = str;
     const char *boundary = wildcard_str;
 
-    char *ptr = strchr(boundary, '*');
+    const char *ptr = strchr(boundary, '*');
 
     /* Check if the wildcard contains wildcard, else compare strings */
     if (NULL == ptr) {

--- a/src/platform/net/zephyr/net.c
+++ b/src/platform/net/zephyr/net.c
@@ -67,7 +67,7 @@ mender_net_get_host_port_url(const char *path, const char *config_host, char **h
     }
 
     /* Extract url path: next '/' character in the path after finding protocol must be the beginning of url */
-    char *path_url = strchr(path_no_prefix, '/');
+    const char *path_url = strchr(path_no_prefix, '/');
     if ((NULL != path_url) && (NULL != url)) {
         if (NULL == (*url = mender_utils_strdup(path_url))) {
             mender_log_error("Unable to allocate memory for URL");
@@ -76,7 +76,7 @@ mender_net_get_host_port_url(const char *path, const char *config_host, char **h
     }
 
     /* Extract host and port */
-    char *path_port = strchr(path_no_prefix, ':');
+    const char *path_port = strchr(path_no_prefix, ':');
     if ((NULL == path_port) && (NULL == path_url)) {
         *port = mender_utils_strdup(is_https ? "443" : "80");
         *host = mender_utils_strdup(path_no_prefix);


### PR DESCRIPTION
This fixes the following errors on machines with glibc >= 2.43 because strstr now returns a const char *.

```
src/core/utils.c:567:17: error: initialization discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
    567 |     char *ptr = strchr(boundary, '*');
        |                 ^~~~~~
src/core/utils.c:589:9: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
    589 |     ptr = strchr(boundary, '*');
        |         ^
cc1: all warnings being treated as errors
```

Ticket: None
Changelog: None

Signed-off-by: Adam Duskett <aduskett@gmail.com>